### PR TITLE
[Bugfix] GitHub submodule icons

### DIFF
--- a/src/lib/replace-icon.ts
+++ b/src/lib/replace-icon.ts
@@ -28,8 +28,13 @@ export function replaceIconInRow(
 ): void {
   const fileName = itemRow
     .querySelector(provider.selectors.filename)
-    ?.textContent?.split('/')[0]
-    .trim();
+    ?.textContent// get the last folder for the icon
+    ?.split('/')
+    .reverse()[0]
+    .trim()
+    // remove possible sha from submodule
+    // matches 4 or more to future proof in case they decide to increase it.
+    .replace(/\s+@\s+[a-fA-F0-9]{4,}$/, '');
   if (!fileName) return;
 
   const iconEl = itemRow.querySelector(


### PR DESCRIPTION
Fixes #92, where submodule name was not correctly detected when choosing an icon.

Added additional fix where when there are nested folders, the extension checks the top most level for the icon instead of the last level, now working like in vscode.

I think we can close #75, too.