### PR TITLE
[Bugfix] Added back scripting permission

### DIFF
--- a/src/manifests/base.json
+++ b/src/manifests/base.json
@@ -30,5 +30,5 @@
     "page": "options.html",
     "open_in_tab": true
   },
-  "permissions": ["storage", "activeTab"]
+  "permissions": ["storage", "activeTab", "scripting"]
 }


### PR DESCRIPTION
For some reason, the scripting permission was removed from the extension manifest. It is needed in chromium browsers for the ability to request access to custom websites,

 Closes #96