### PR TITLE
fix: update selectors for Gitea provider

### DIFF
--- a/src/providers/gitea.ts
+++ b/src/providers/gitea.ts
@@ -10,10 +10,9 @@ export default function gitea(): Provider {
       },
     ],
     selectors: {
-      row: 'tr.ready.entry, details.download ul.list li',
-      filename:
-        'td.name.four.wide > span.truncate > a, a[download] strong, a.archive-link strong',
-      icon: 'td.name.four.wide > span.truncate > svg, .octicon-package, .octicon-file-zip',
+      row: '#repo-files-table .repo-file-item',
+      filename: '.repo-file-cell.name a',
+      icon: '.repo-file-cell.name svg',
       // Element by which to detect if the tested domain is gitea.
       detect: 'body > .full.height > .page-content[role=main]',
     },


### PR DESCRIPTION
I have updated the Gitea selectors since the old ones don’t seem to work anymore. This may partially fix #118.