### PR TITLE
fix: custom GitLab domain on Firefox

### DIFF
--- a/src/providers/gitlab.ts
+++ b/src/providers/gitlab.ts
@@ -16,13 +16,13 @@ export default function gitlab(): Provider {
          .file-header-content,
          .gl-card[data-testid="release-block"] .js-assets-list ul li`,
       // Cell in file list, file view header, readme header
-      filename: `td.tree-item-file-name .tree-item-link,
-        td.tree-item-file-name,
+      filename: `.tree-item-file-name .tree-item-link,
+        .tree-item-file-name,
         .file-header-content .file-title-name,
         .file-header-content .gl-link,
         .gl-link`,
       // Any icon not contained in a button
-      icon: `td.tree-item-file-name .tree-item-link svg,
+      icon: `.tree-item-file-name .tree-item-link svg,
         .tree-item svg, .file-header-content svg:not(.gl-button-icon),
         .gl-link svg.gl-icon[data-testid="doc-code-icon"]`,
       // Element by which to detect if the tested domain is gitlab.

--- a/src/ui/popup/components/ask-for-access.tsx
+++ b/src/ui/popup/components/ask-for-access.tsx
@@ -1,8 +1,16 @@
 import { Box, Button, Typography } from '@mui/material';
+import { useEffect, useState } from 'react';
 import { requestAccess } from '../api/access';
 import { getCurrentTab } from '../api/helper';
+import Browser from 'webextension-polyfill';
 
 export function AskForAccess() {
+  const [currentTab, setCurrentTab] = useState<Browser.Tabs.Tab | null>(null);
+
+  useEffect(() => {
+    getCurrentTab().then(setCurrentTab);
+  }, []);
+
   return (
     <Box sx={{ p: 2 }}>
       <Typography variant='body1'>
@@ -13,7 +21,9 @@ export function AskForAccess() {
         <Button
           variant='contained'
           onClick={() => {
-            getCurrentTab().then(requestAccess);
+            if (currentTab) {
+              requestAccess(currentTab);
+            }
           }}
         >
           Grant Access

--- a/src/ui/popup/components/ask-for-access.tsx
+++ b/src/ui/popup/components/ask-for-access.tsx
@@ -1,8 +1,8 @@
 import { Box, Button, Typography } from '@mui/material';
 import { useEffect, useState } from 'react';
+import Browser from 'webextension-polyfill';
 import { requestAccess } from '../api/access';
 import { getCurrentTab } from '../api/helper';
-import Browser from 'webextension-polyfill';
 
 export function AskForAccess() {
   const [currentTab, setCurrentTab] = useState<Browser.Tabs.Tab | null>(null);


### PR DESCRIPTION
## Changes

- fix selectors for GitLab
- apply fix for the request access button
  - the button cannot be called on firefox withing an async function