### PR TITLE
feat: enhance "Files Changed" experience

### DIFF
--- a/src/providers/github.ts
+++ b/src/providers/github.ts
@@ -31,6 +31,7 @@ export default function github(): Provider {
         .octicon-file-zip,
         .octicon-file-diff,
         .octicon-file-added,
+        .octicon-file-moved,
         .octicon-file-removed`,
       // Element by which to detect if the tested domain is github.
       detect: 'body > div[data-turbo-body]',
@@ -86,6 +87,22 @@ export default function github(): Provider {
       else {
         svgEl.style.display = 'none';
         svgEl.before(newSVG);
+      }
+
+      // Get the fgColor-* class from the original svg element
+      // and apply it to the link next to the icon.
+      const fgColorClass = Array.from(svgEl.classList).find((className) =>
+        className.startsWith('fgColor-')
+      );
+      // The fgColor-muted is the same as the fgColor-default,
+      // so we don't need to copy that class.
+      if (fgColorClass && fgColorClass !== 'fgColor-muted') {
+        const link =
+          svgEl.parentElement?.nextElementSibling?.querySelector('a');
+        if (link) {
+          // This will overwrite existing fgColor- classes.
+          link.classList.add(fgColorClass);
+        }
       }
     },
     onAdd: () => {},


### PR DESCRIPTION
Supplement to #135

* add missing icon class target `.oction-file-moved`
* apply the color of original svg to the link, since the original svg is hiden

The original Github Pull Request "File Changed" page:

<img width="362" height="776" alt="origin" src="https://github.com/user-attachments/assets/bfed3c9d-e985-4142-b174-bf79b354cc96" />

Previous behavior:

<img width="362" height="776" alt="before" src="https://github.com/user-attachments/assets/fd359a5c-9803-4532-ad34-742b26960fe0" />

New behavior:

<img width="362" height="776" alt="after" src="https://github.com/user-attachments/assets/3342c1ea-515a-4352-abe9-32044e1bf780" />


