### PR TITLE
fix: conflict with Refined GitHub

### DIFF
--- a/src/injected-styles.css
+++ b/src/injected-styles.css
@@ -17,11 +17,6 @@ body[data-material-icons-extension-size="xl"]
   display: none !important;
 }
 
-/* Hide native icons that immediately follow the replaced icon */
-img[data-material-icons-extension="icon"] + svg {
-  display: none !important;
-}
-
 /* github package icon spacing fix */
 .octicon-package[data-material-icons-extension] {
   margin-right: 5px;

--- a/src/providers/github.ts
+++ b/src/providers/github.ts
@@ -95,6 +95,7 @@ export default function github(): Provider {
       // https://github.com/material-extensions/material-icons-browser-extension/pull/66
       // https://github.com/material-extensions/material-icons-browser-extension/issues/142
       else {
+        svgEl.style.display = 'none';
         svgEl.before(newSVG);
       }
 


### PR DESCRIPTION
- fixes https://github.com/material-extensions/material-icons-browser-extension/pull/143#pullrequestreview-4350040136
- partially reverts https://github.com/material-extensions/material-icons-browser-extension/pull/143
- restores https://github.com/material-extensions/material-icons-browser-extension/pull/66