### PR TITLE
fix: improve extension with tests and fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,5 +27,8 @@ jobs:
       - name: 🧹 Check code quality
         run: npm run lint
 
+      - name: 🧪 Run tests
+        run: npm test
+
       - name: 🛠️ Build extension
         run: npm run build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     name: Build Material Icons Browser Extension
     steps:
       - name: 🛎️ Checkout
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -20,6 +24,12 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
+      - name: 📌 Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
 
       - name: 📦 Install dependencies
         run: npm ci
@@ -50,6 +60,12 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: 📌 Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
       - name: 📦 Install dependencies
         run: npm ci
 
@@ -76,3 +92,13 @@ jobs:
 
       - name: 🧪 Run e2e tests
         run: xvfb-run npx playwright test
+
+      - name: 📤 Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            playwright-report/
+            test-results/
+          retention-days: 7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,3 +32,25 @@ jobs:
 
       - name: 🛠️ Build extension
         run: npm run build
+
+  e2e:
+    runs-on: [ubuntu-latest]
+    name: E2E Tests
+    needs: build
+    steps:
+      - name: 🛎️ Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: 📦 Install dependencies
+        run: npm ci
+
+      - name: 🛠️ Build extension
+        run: npm run build
+
+      - name: 🎭 Install Playwright browsers
+        run: npx playwright install chromium --with-deps
+
+      - name: 🧪 Run e2e tests
+        run: xvfb-run npx playwright test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,8 +49,20 @@ jobs:
       - name: 🛠️ Build extension
         run: npm run build
 
+      - name: 🎭 Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ hashFiles('package-lock.json') }}
+
       - name: 🎭 Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install chromium --with-deps
+
+      - name: 🎭 Install Playwright system deps
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
 
       - name: 🧪 Run e2e tests
         run: xvfb-run npx playwright test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,13 @@ jobs:
       - name: 🛠️ Build extension
         run: npm run build
 
+      - name: 📤 Upload extension build
+        uses: actions/upload-artifact@v4
+        with:
+          name: extension-build
+          path: dist/chrome-edge/
+          retention-days: 1
+
   e2e:
     runs-on: [ubuntu-latest]
     name: E2E Tests
@@ -46,8 +53,11 @@ jobs:
       - name: 📦 Install dependencies
         run: npm ci
 
-      - name: 🛠️ Build extension
-        run: npm run build
+      - name: 📥 Download extension build
+        uses: actions/download-artifact@v4
+        with:
+          name: extension-build
+          path: dist/chrome-edge/
 
       - name: 🎭 Cache Playwright browsers
         id: playwright-cache

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # Only fetch the config file from the repository
           sparse-checkout-cone-mode: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           persist-credentials: false
@@ -82,7 +82,7 @@ jobs:
           private-key: ${{ secrets.BOT_PRIVATE_KEY }}
 
       - name: 📥 Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ node_modules
 Thumbs.db
 
 .env
+test-results/

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ Thumbs.db
 
 .env
 test-results/
+playwright-report/

--- a/e2e/github.spec.ts
+++ b/e2e/github.spec.ts
@@ -1,0 +1,142 @@
+import { test, expect, chromium, type BrowserContext } from '@playwright/test';
+import path from 'path';
+
+const extensionPath = path.resolve(__dirname, '..', 'dist', 'chrome-edge');
+
+test.describe('GitHub icon replacement', () => {
+  let context: BrowserContext;
+
+  test.beforeAll(async () => {
+    context = await chromium.launchPersistentContext('', {
+      headless: false,
+      args: [
+        `--disable-extensions-except=${extensionPath}`,
+        `--load-extension=${extensionPath}`,
+        '--no-first-run',
+        '--disable-gpu',
+      ],
+    });
+  });
+
+  test.afterAll(async () => {
+    await context.close();
+  });
+
+  test('should replace file icons on a GitHub repository page', async () => {
+    const page = await context.newPage();
+    await page.goto(
+      'https://github.com/material-extensions/material-icons-browser-extension',
+      { waitUntil: 'networkidle' }
+    );
+
+    // Wait for at least one icon to be replaced
+    await page
+      .locator('[data-material-icons-extension="icon"]')
+      .first()
+      .waitFor({ state: 'attached', timeout: 15000 });
+
+    // Check that multiple icons have been replaced
+    const replacedIcons = await page
+      .locator('[data-material-icons-extension="icon"]')
+      .count();
+    expect(replacedIcons).toBeGreaterThan(5);
+
+    // Verify specific known files have correct icons
+    await expect(
+      page.locator('[data-material-icons-extension-filename="tsconfig.json"]').first()
+    ).toBeAttached();
+
+    await expect(
+      page.locator('[data-material-icons-extension-filename="package.json"]').first()
+    ).toBeAttached();
+
+    await page.close();
+  });
+
+  test('should replace folder icons with material icons', async () => {
+    const page = await context.newPage();
+    await page.goto(
+      'https://github.com/material-extensions/material-icons-browser-extension',
+      { waitUntil: 'networkidle' }
+    );
+
+    await page
+      .locator('[data-material-icons-extension="icon"]')
+      .first()
+      .waitFor({ state: 'attached', timeout: 15000 });
+
+    // Check that the src folder has a material icon with background-image
+    const srcIcon = page.locator(
+      '[data-material-icons-extension-filename="src"]'
+    ).first();
+    await expect(srcIcon).toBeAttached();
+
+    const bgImage = await srcIcon.evaluate(
+      (el) => (el as HTMLElement).style.backgroundImage
+    );
+    expect(bgImage).toContain('folder-src');
+
+    await page.close();
+  });
+
+  test('should apply background-image on SVG (not insert img elements)', async () => {
+    const page = await context.newPage();
+    await page.goto(
+      'https://github.com/material-extensions/material-icons-browser-extension',
+      { waitUntil: 'networkidle' }
+    );
+
+    await page
+      .locator('[data-material-icons-extension="icon"]')
+      .first()
+      .waitFor({ state: 'attached', timeout: 15000 });
+
+    // Ensure no <img> elements from the extension exist in the tree view
+    const treeImgs = await page
+      .locator('img[data-material-icons-extension="icon"]')
+      .count();
+    expect(treeImgs).toBe(0);
+
+    // Ensure SVGs have background-image set
+    const bgImage = await page
+      .locator('svg[data-material-icons-extension="icon"]')
+      .first()
+      .evaluate((el) => (el as HTMLElement).style.backgroundImage);
+    expect(bgImage).toContain('url(');
+
+    await page.close();
+  });
+
+  test('should show open folder icon when expanding a folder', async () => {
+    const page = await context.newPage();
+    await page.goto(
+      'https://github.com/material-extensions/material-icons-browser-extension',
+      { waitUntil: 'networkidle' }
+    );
+
+    await page
+      .locator('[data-material-icons-extension="icon"]')
+      .first()
+      .waitFor({ state: 'attached', timeout: 15000 });
+
+    // Find any collapsed folder and click to expand it
+    const collapsedFolder = page.locator(
+      '[role="treeitem"][aria-expanded="false"]'
+    ).first();
+
+    if ((await collapsedFolder.count()) > 0) {
+      await collapsedFolder.click();
+      // Wait for the open icon to appear
+      await page.waitForTimeout(2000);
+
+      // Look for any open folder icon
+      const openIcons = page.locator(
+        '[data-material-icons-extension-iconname*="-open.svg"]'
+      );
+      const count = await openIcons.count();
+      expect(count).toBeGreaterThanOrEqual(1);
+    }
+
+    await page.close();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "material-icons-browser-extension",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "material-icons-browser-extension",
-      "version": "1.15.0",
+      "version": "1.16.0",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "11.14.0",
@@ -21,6 +21,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.1.2",
+        "@testing-library/dom": "10.4.1",
         "@types/fs-extra": "11.0.4",
         "@types/node": "24.0.14",
         "@types/react": "19.1.8",
@@ -29,6 +30,7 @@
         "esbuild": "0.25.6",
         "fs-extra": "11.3.0",
         "husky": "9.1.7",
+        "jsdom": "29.1.1",
         "lint-staged": "16.1.2",
         "nodemon": "3.1.10",
         "npm-run-all": "4.1.5",
@@ -36,8 +38,60 @@
         "sharp": "0.34.3",
         "tsx": "4.22.3",
         "typescript": "5.8.3",
+        "vitest": "4.1.7",
         "web-ext": "8.9.0"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -341,6 +395,159 @@
         "node": ">=14.21.3"
       }
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.1.tgz",
+      "integrity": "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.4.tgz",
+      "integrity": "sha512-wgsqt92b7C7tQhIdPNxj0n9zuUbQlvAuI1exyzeNrOKOi62SD7ren8zqszmpVREjAOqg8cD2FqYhQfAuKjk4sw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
     "node_modules/@devicefarmer/adbkit": {
       "version": "3.3.8",
       "resolved": "https://registry.npmjs.org/@devicefarmer/adbkit/-/adbkit-3.3.8.tgz",
@@ -411,10 +618,33 @@
         }
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/runtime": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.5.tgz",
-      "integrity": "sha512-++LApOtY0pEEz1zrd9vy1/zXVaVJJ/EbAF3u0fXIzPJEDtnITsBGbbK0EkM72amhl/R5b+5xx0Y/QhcVOpuulg==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1154,6 +1384,24 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@fluent/syntax": {
       "version": "0.19.0",
       "resolved": "https://registry.npmjs.org/@fluent/syntax/-/syntax-0.19.0.tgz",
@@ -1770,9 +2018,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.4.tgz",
-      "integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
@@ -2025,6 +2273,25 @@
         }
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2061,6 +2328,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.132.0.tgz",
+      "integrity": "sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
       }
     },
     "node_modules/@pnpm/config.env-replace": {
@@ -2117,6 +2394,340 @@
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
       }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.2.tgz",
+      "integrity": "sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.2.tgz",
+      "integrity": "sha512-vdFA9+C/rekyGce7WqHs/xoT0ioZEWaOFyZLIV1mEeNFaFDUQrPIo8Vs2GvJ6eetb3rzDUtUBgzto3ExpXJB3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.2.tgz",
+      "integrity": "sha512-BewSOwTHazv77DTYiAZXSqqKZ4KP/KonFisDMVU7PImxoWfB2aepnPhd2E4SWz3zDzYgDNbs6jBmTdgNnF02GA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.2.tgz",
+      "integrity": "sha512-m41o7M0YWtUdqk61Tb+jnKb2rN++iRdIASlExkUoKfIAH30DOHCB8fVLzSUpbWHHU8esmEioY62PxzexE8MBuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.2.tgz",
+      "integrity": "sha512-jcojB9H7W/jS29pMKWAK1N+fU99vXodHDTatS3b3y/XSOCiHo0kkA74pL3jJmkoQtYpOCxDvaKs1fo2Ij/1X5w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.2.tgz",
+      "integrity": "sha512-1jn6qDU5iiOgFgygDzKUuKP0maTi0/f1+sBLgvij/76C77Nm3ts6ufz9Bjg5q5dduxiUIxtq86JIoBvo1xQ4Ig==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.2.tgz",
+      "integrity": "sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.2.tgz",
+      "integrity": "sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.2.tgz",
+      "integrity": "sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.2.tgz",
+      "integrity": "sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.2.tgz",
+      "integrity": "sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.2.tgz",
+      "integrity": "sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.2.tgz",
+      "integrity": "sha512-mb1VobWn6NheziTk5/WEaR6AKVbrwT5sOi6C7zk3gy/pD1qtJfU1j4PgTo2NJnOtbL9Dl3Aeei8w9jJ7qC2jZQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.2.tgz",
+      "integrity": "sha512-SqKonF56vA/L2yHwHYcEp2P34URpOZ7d1fS635cTkpDnUtEGdUbhI6NzsPdqeSWvAAeGDrxjWjNmibDIdFf9/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.2.tgz",
+      "integrity": "sha512-v7qRI7gXLRINcOGXt+7YmAZ6iFuyZVMIoXAxhd8oP+DR9dLfL9GfNIx7PLMxmhZdvq8waUJBQiWN9EKNy+TRBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/fs-extra": {
       "version": "11.0.4",
@@ -2216,6 +2827,99 @@
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.7.tgz",
+      "integrity": "sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.7.tgz",
+      "integrity": "sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.7.tgz",
+      "integrity": "sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.7",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.7.tgz",
+      "integrity": "sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.7.tgz",
+      "integrity": "sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.7.tgz",
+      "integrity": "sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.7",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/acorn": {
       "version": "8.15.0",
@@ -2495,6 +3199,16 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz",
@@ -2561,6 +3275,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/async": {
@@ -2653,6 +3377,16 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "tweetnacl": "^0.14.3"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/binary-extensions": {
@@ -2934,6 +3668,16 @@
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
       "license": "Apache-2.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -3539,6 +4283,20 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/css-what": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
@@ -3568,6 +4326,20 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/data-view-buffer": {
@@ -3655,6 +4427,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/deep-extend": {
       "version": "0.6.0",
@@ -3796,6 +4575,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
@@ -3818,6 +4607,13 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -4087,6 +4883,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -4459,6 +5262,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -4491,6 +5304,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/extend": {
@@ -5398,6 +6221,19 @@
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/htmlparser2": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
@@ -6059,6 +6895,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
@@ -6250,6 +7093,86 @@
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/jsdom/node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/jsdom/node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -6477,6 +7400,267 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
     },
     "node_modules/lilconfig": {
       "version": "3.1.3",
@@ -6708,13 +7892,33 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.1.0.tgz",
-      "integrity": "sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==",
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
+      "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/make-error": {
@@ -6758,6 +7962,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/memorystream": {
       "version": "0.3.1",
@@ -6911,6 +8122,25 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/nano-spawn?sponsor=1"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/natural-compare": {
@@ -7318,6 +8548,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/on-exit-leak-free": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
@@ -7599,6 +8840,13 @@
         "node": ">=4"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -7701,6 +8949,35 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -7710,6 +8987,51 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
@@ -8200,6 +9522,40 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rolldown": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.2.tgz",
+      "integrity": "sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.132.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.2",
+        "@rolldown/binding-darwin-arm64": "1.0.2",
+        "@rolldown/binding-darwin-x64": "1.0.2",
+        "@rolldown/binding-freebsd-x64": "1.0.2",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.2",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.2",
+        "@rolldown/binding-linux-arm64-musl": "1.0.2",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.2",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.2",
+        "@rolldown/binding-linux-x64-gnu": "1.0.2",
+        "@rolldown/binding-linux-x64-musl": "1.0.2",
+        "@rolldown/binding-openharmony-arm64": "1.0.2",
+        "@rolldown/binding-wasm32-wasi": "1.0.2",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.2",
+        "@rolldown/binding-win32-x64-msvc": "1.0.2"
+      }
+    },
     "node_modules/run-applescript": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.0.0.tgz",
@@ -8319,6 +9675,19 @@
       "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.26.0",
@@ -8521,6 +9890,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -8606,6 +9982,16 @@
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -8723,6 +10109,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.1.1",
@@ -9018,6 +10418,13 @@
         "xml-reader": "2.4.3"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -9060,6 +10467,101 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.30",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.30.tgz",
+      "integrity": "sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.30"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.30",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.30.tgz",
+      "integrity": "sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tmp": {
@@ -9105,6 +10607,19 @@
       },
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/tslib": {
@@ -9777,6 +11292,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
@@ -9912,6 +11437,757 @@
         "extsprintf": "^1.2.0"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.7.tgz",
+      "integrity": "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.7",
+        "@vitest/mocker": "4.1.7",
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/runner": "4.1.7",
+        "@vitest/snapshot": "4.1.7",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.7",
+        "@vitest/browser-preview": "4.1.7",
+        "@vitest/browser-webdriverio": "4.1.7",
+        "@vitest/coverage-istanbul": "4.1.7",
+        "@vitest/coverage-v8": "4.1.7",
+        "@vitest/ui": "4.1.7",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.7.tgz",
+      "integrity": "sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "8.0.14",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.14.tgz",
+      "integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.2",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/watchpack": {
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.4.tgz",
@@ -10040,6 +12316,41 @@
       "integrity": "sha512-97TBmpoWJEE+3nFBQ4VocyCdLKfw54rFaJ6EVQYLBCXqCIpLSZkwGgASpv4oPt9gdKCJ80RJlcmNzNn008Ag6Q==",
       "license": "MPL-2.0"
     },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/when": {
       "version": "3.7.7",
       "resolved": "https://registry.npmjs.org/when/-/when-3.7.7.tgz",
@@ -10102,6 +12413,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/widest-line": {
@@ -10343,6 +12671,16 @@
       "integrity": "sha512-jLN68Dx5kyFHaePoXWPsCGW5qdyZQtLYHkxkg02/Mz6g0kYpDx4FyP6XfArhQdlOC4b8Mv+EMxPo/8La7Tzghg==",
       "license": "MIT"
     },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/xml-reader": {
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/xml-reader/-/xml-reader-2.4.3.tgz",
@@ -10382,6 +12720,13 @@
       "engines": {
         "node": ">=4.0"
       }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",
@@ -10522,6 +12867,44 @@
     }
   },
   "dependencies": {
+    "@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "requires": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "requires": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      }
+    },
+    "@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true
+    },
+    "@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true
+    },
     "@babel/code-frame": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
@@ -10686,6 +13069,58 @@
       "dev": true,
       "optional": true
     },
+    "@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "requires": {
+        "css-tree": "^3.0.0"
+      }
+    },
+    "@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true
+    },
+    "@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "requires": {}
+    },
+    "@csstools/css-color-parser": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.1.tgz",
+      "integrity": "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==",
+      "dev": true,
+      "requires": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.1"
+      }
+    },
+    "@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "requires": {}
+    },
+    "@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.4.tgz",
+      "integrity": "sha512-wgsqt92b7C7tQhIdPNxj0n9zuUbQlvAuI1exyzeNrOKOi62SD7ren8zqszmpVREjAOqg8cD2FqYhQfAuKjk4sw==",
+      "dev": true,
+      "requires": {}
+    },
+    "@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true
+    },
     "@devicefarmer/adbkit": {
       "version": "3.3.8",
       "resolved": "https://registry.npmjs.org/@devicefarmer/adbkit/-/adbkit-3.3.8.tgz",
@@ -10730,10 +13165,31 @@
       "integrity": "sha512-ZzZY/b66W2Jd6NHbAhLyDWOEIBWC11VizGFk7Wx7M61JZRz7HR9Cq5P+65RKWUU7u6wgsE8Lmh9nE4Mz+U2eTg==",
       "dev": true
     },
+    "@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
     "@emnapi/runtime": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.5.tgz",
-      "integrity": "sha512-++LApOtY0pEEz1zrd9vy1/zXVaVJJ/EbAF3u0fXIzPJEDtnITsBGbbK0EkM72amhl/R5b+5xx0Y/QhcVOpuulg==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -11125,6 +13581,13 @@
       "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
       "dev": true
     },
+    "@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "requires": {}
+    },
     "@fluent/syntax": {
       "version": "0.19.0",
       "resolved": "https://registry.npmjs.org/@fluent/syntax/-/syntax-0.19.0.tgz",
@@ -11424,9 +13887,9 @@
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="
     },
     "@jridgewell/sourcemap-codec": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.4.tgz",
-      "integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw=="
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="
     },
     "@jridgewell/trace-mapping": {
       "version": "0.3.29",
@@ -11534,6 +13997,16 @@
         "react-is": "^19.1.0"
       }
     },
+    "@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@tybys/wasm-util": "^0.10.1"
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -11559,6 +14032,12 @@
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
+    },
+    "@oxc-project/types": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.132.0.tgz",
+      "integrity": "sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==",
+      "dev": true
     },
     "@pnpm/config.env-replace": {
       "version": "1.1.0",
@@ -11598,6 +14077,182 @@
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="
+    },
+    "@rolldown/binding-android-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.2.tgz",
+      "integrity": "sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@rolldown/binding-darwin-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.2.tgz",
+      "integrity": "sha512-vdFA9+C/rekyGce7WqHs/xoT0ioZEWaOFyZLIV1mEeNFaFDUQrPIo8Vs2GvJ6eetb3rzDUtUBgzto3ExpXJB3w==",
+      "dev": true,
+      "optional": true
+    },
+    "@rolldown/binding-darwin-x64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.2.tgz",
+      "integrity": "sha512-BewSOwTHazv77DTYiAZXSqqKZ4KP/KonFisDMVU7PImxoWfB2aepnPhd2E4SWz3zDzYgDNbs6jBmTdgNnF02GA==",
+      "dev": true,
+      "optional": true
+    },
+    "@rolldown/binding-freebsd-x64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.2.tgz",
+      "integrity": "sha512-m41o7M0YWtUdqk61Tb+jnKb2rN++iRdIASlExkUoKfIAH30DOHCB8fVLzSUpbWHHU8esmEioY62PxzexE8MBuA==",
+      "dev": true,
+      "optional": true
+    },
+    "@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.2.tgz",
+      "integrity": "sha512-jcojB9H7W/jS29pMKWAK1N+fU99vXodHDTatS3b3y/XSOCiHo0kkA74pL3jJmkoQtYpOCxDvaKs1fo2Ij/1X5w==",
+      "dev": true,
+      "optional": true
+    },
+    "@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.2.tgz",
+      "integrity": "sha512-1jn6qDU5iiOgFgygDzKUuKP0maTi0/f1+sBLgvij/76C77Nm3ts6ufz9Bjg5q5dduxiUIxtq86JIoBvo1xQ4Ig==",
+      "dev": true,
+      "optional": true
+    },
+    "@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.2.tgz",
+      "integrity": "sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==",
+      "dev": true,
+      "optional": true
+    },
+    "@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.2.tgz",
+      "integrity": "sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==",
+      "dev": true,
+      "optional": true
+    },
+    "@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.2.tgz",
+      "integrity": "sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.2.tgz",
+      "integrity": "sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.2.tgz",
+      "integrity": "sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==",
+      "dev": true,
+      "optional": true
+    },
+    "@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.2.tgz",
+      "integrity": "sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==",
+      "dev": true,
+      "optional": true
+    },
+    "@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.2.tgz",
+      "integrity": "sha512-mb1VobWn6NheziTk5/WEaR6AKVbrwT5sOi6C7zk3gy/pD1qtJfU1j4PgTo2NJnOtbL9Dl3Aeei8w9jJ7qC2jZQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      }
+    },
+    "@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.2.tgz",
+      "integrity": "sha512-SqKonF56vA/L2yHwHYcEp2P34URpOZ7d1fS635cTkpDnUtEGdUbhI6NzsPdqeSWvAAeGDrxjWjNmibDIdFf9/A==",
+      "dev": true,
+      "optional": true
+    },
+    "@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.2.tgz",
+      "integrity": "sha512-v7qRI7gXLRINcOGXt+7YmAZ6iFuyZVMIoXAxhd8oP+DR9dLfL9GfNIx7PLMxmhZdvq8waUJBQiWN9EKNy+TRBQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true
+    },
+    "@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true
+    },
+    "@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      }
+    },
+    "@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true
+    },
+    "@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "requires": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true
+    },
+    "@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true
     },
     "@types/fs-extra": {
       "version": "11.0.4",
@@ -11684,6 +14339,76 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "dev": true
+    },
+    "@vitest/expect": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.7.tgz",
+      "integrity": "sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==",
+      "dev": true,
+      "requires": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      }
+    },
+    "@vitest/pretty-format": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.7.tgz",
+      "integrity": "sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==",
+      "dev": true,
+      "requires": {
+        "tinyrainbow": "^3.1.0"
+      }
+    },
+    "@vitest/runner": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.7.tgz",
+      "integrity": "sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==",
+      "dev": true,
+      "requires": {
+        "@vitest/utils": "4.1.7",
+        "pathe": "^2.0.3"
+      }
+    },
+    "@vitest/snapshot": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.7.tgz",
+      "integrity": "sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==",
+      "dev": true,
+      "requires": {
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      }
+    },
+    "@vitest/spy": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.7.tgz",
+      "integrity": "sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==",
+      "dev": true
+    },
+    "@vitest/utils": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.7.tgz",
+      "integrity": "sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==",
+      "dev": true,
+      "requires": {
+        "@vitest/pretty-format": "4.1.7",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "dependencies": {
+        "convert-source-map": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+          "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+          "dev": true
+        }
+      }
     },
     "acorn": {
       "version": "8.15.0",
@@ -11872,6 +14597,15 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
+    "aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "requires": {
+        "dequal": "^2.0.3"
+      }
+    },
     "array-buffer-byte-length": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz",
@@ -11916,6 +14650,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw=="
+    },
+    "assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true
     },
     "async": {
       "version": "3.2.5",
@@ -11984,6 +14724,15 @@
       "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
       "requires": {
         "tweetnacl": "^0.14.3"
+      }
+    },
+    "bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "requires": {
+        "require-from-string": "^2.0.2"
       }
     },
     "binary-extensions": {
@@ -12172,6 +14921,12 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
+    },
+    "chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true
     },
     "chalk": {
       "version": "4.1.2",
@@ -12601,6 +15356,16 @@
         "nth-check": "^2.0.1"
       }
     },
+    "css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "requires": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      }
+    },
     "css-what": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
@@ -12618,6 +15383,16 @@
       "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
       "requires": {
         "assert-plus": "^1.0.0"
+      }
+    },
+    "data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "requires": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
       }
     },
     "data-view-buffer": {
@@ -12671,6 +15446,12 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-6.0.0.tgz",
       "integrity": "sha512-Fv96DCsdOgB6mdGl67MT5JaTNKRzrzill5OH5s8bjYJXVlcXyPYGyPsUkWyGV5p1TXI5esYIYMMeDJL0hEIwaA==",
+      "dev": true
+    },
+    "decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true
     },
     "deep-extend": {
@@ -12758,6 +15539,12 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
+    "dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true
+    },
     "detect-libc": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
@@ -12772,6 +15559,12 @@
       "requires": {
         "esutils": "^2.0.2"
       }
+    },
+    "dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true
     },
     "dom-helpers": {
       "version": "5.2.1",
@@ -12968,6 +15761,12 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true
+    },
+    "es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true
     },
     "es-object-atoms": {
@@ -13220,6 +16019,15 @@
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true
     },
+    "estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -13241,6 +16049,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
       "integrity": "sha512-MsG3prOVw1WtLXAZbM3KiYtooKR1LvxHh3VHsVtIy0uiUu8usxgB/94DP2HxtD/661lLdB6yzQ09lGJSQr6nkg=="
+    },
+    "expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true
     },
     "extend": {
       "version": "3.0.2",
@@ -13871,6 +16685,15 @@
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
+    "html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "requires": {
+        "@exodus/bytes": "^1.6.0"
+      }
+    },
     "htmlparser2": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
@@ -14287,6 +17110,12 @@
       "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
       "dev": true
     },
+    "is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true
+    },
     "is-regex": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
@@ -14418,6 +17247,61 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg=="
+    },
+    "jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "requires": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "dependencies": {
+        "entities": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+          "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+          "dev": true
+        },
+        "parse5": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+          "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+          "dev": true,
+          "requires": {
+            "entities": "^8.0.0"
+          }
+        },
+        "tough-cookie": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+          "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+          "dev": true,
+          "requires": {
+            "tldts": "^7.0.5"
+          }
+        }
+      }
     },
     "jsesc": {
       "version": "3.1.0",
@@ -14599,6 +17483,103 @@
         }
       }
     },
+    "lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "requires": {
+        "detect-libc": "^2.0.3",
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "dev": true,
+      "optional": true
+    },
+    "lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "dev": true,
+      "optional": true
+    },
+    "lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "dev": true,
+      "optional": true
+    },
+    "lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "dev": true,
+      "optional": true
+    },
+    "lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "dev": true,
+      "optional": true
+    },
+    "lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "dev": true,
+      "optional": true
+    },
+    "lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "dev": true,
+      "optional": true
+    },
+    "lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "dev": true,
+      "optional": true
+    },
+    "lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "dev": true,
+      "optional": true
+    },
+    "lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "dev": true,
+      "optional": true
+    },
+    "lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "dev": true,
+      "optional": true
+    },
     "lilconfig": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
@@ -14744,10 +17725,25 @@
       }
     },
     "lru-cache": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.1.0.tgz",
-      "integrity": "sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==",
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
+      "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
       "dev": true
+    },
+    "lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true
+    },
+    "magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
     },
     "make-error": {
       "version": "1.3.6",
@@ -14777,6 +17773,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true
+    },
+    "mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "dev": true
     },
     "memorystream": {
@@ -14878,6 +17880,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/nano-spawn/-/nano-spawn-1.0.2.tgz",
       "integrity": "sha512-21t+ozMQDAL/UGgQVBbZ/xXvNO10++ZPuTmKRO8k9V3AClVRht49ahtDjfY8l1q6nSHOrE5ASfthzH3ol6R/hg==",
+      "dev": true
+    },
+    "nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true
     },
     "natural-compare": {
@@ -15174,6 +18182,12 @@
         "object-keys": "^1.1.1"
       }
     },
+    "obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true
+    },
     "on-exit-leak-free": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
@@ -15362,6 +18376,12 @@
         "pify": "^3.0.0"
       }
     },
+    "pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true
+    },
     "pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -15436,11 +18456,53 @@
       "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==",
       "dev": true
     },
+    "postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "requires": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      }
+    },
     "prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true
+    },
+    "pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+          "dev": true
+        },
+        "react-is": {
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+          "dev": true
+        }
+      }
     },
     "process-nextick-args": {
       "version": "2.0.1",
@@ -15774,6 +18836,31 @@
         "package-json-from-dist": "^1.0.0"
       }
     },
+    "rolldown": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.2.tgz",
+      "integrity": "sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==",
+      "dev": true,
+      "requires": {
+        "@oxc-project/types": "=0.132.0",
+        "@rolldown/binding-android-arm64": "1.0.2",
+        "@rolldown/binding-darwin-arm64": "1.0.2",
+        "@rolldown/binding-darwin-x64": "1.0.2",
+        "@rolldown/binding-freebsd-x64": "1.0.2",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.2",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.2",
+        "@rolldown/binding-linux-arm64-musl": "1.0.2",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.2",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.2",
+        "@rolldown/binding-linux-x64-gnu": "1.0.2",
+        "@rolldown/binding-linux-x64-musl": "1.0.2",
+        "@rolldown/binding-openharmony-arm64": "1.0.2",
+        "@rolldown/binding-wasm32-wasi": "1.0.2",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.2",
+        "@rolldown/binding-win32-x64-msvc": "1.0.2",
+        "@rolldown/pluginutils": "^1.0.0"
+      }
+    },
     "run-applescript": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.0.0.tgz",
@@ -15854,6 +18941,15 @@
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
       "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
       "dev": true
+    },
+    "saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "requires": {
+        "xmlchars": "^2.2.0"
+      }
     },
     "scheduler": {
       "version": "0.26.0",
@@ -16010,6 +19106,12 @@
         "object-inspect": "^1.13.1"
       }
     },
+    "siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
     "signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -16073,6 +19175,12 @@
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="
+    },
+    "source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true
     },
     "source-map-support": {
       "version": "0.5.21",
@@ -16164,6 +19272,18 @@
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
       }
+    },
+    "stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
+    "std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true
     },
     "string_decoder": {
       "version": "1.1.1",
@@ -16367,6 +19487,12 @@
         "xml-reader": "2.4.3"
       }
     },
+    "symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -16403,6 +19529,64 @@
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
     },
+    "tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
+    "tinyexec": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "dev": true
+    },
+    "tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "requires": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "dependencies": {
+        "fdir": {
+          "version": "6.5.0",
+          "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+          "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+          "dev": true,
+          "requires": {}
+        },
+        "picomatch": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+          "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+          "dev": true
+        }
+      }
+    },
+    "tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true
+    },
+    "tldts": {
+      "version": "7.0.30",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.30.tgz",
+      "integrity": "sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==",
+      "dev": true,
+      "requires": {
+        "tldts-core": "^7.0.30"
+      }
+    },
+    "tldts-core": {
+      "version": "7.0.30",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.30.tgz",
+      "integrity": "sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==",
+      "dev": true
+    },
     "tmp": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
@@ -16431,6 +19615,15 @@
       "requires": {
         "psl": "^1.1.28",
         "punycode": "^2.1.1"
+      }
+    },
+    "tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.3.1"
       }
     },
     "tslib": {
@@ -16778,6 +19971,12 @@
       "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
       "dev": true
     },
+    "undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true
+    },
     "undici-types": {
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
@@ -16874,6 +20073,328 @@
         "extsprintf": "^1.2.0"
       }
     },
+    "vitest": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.7.tgz",
+      "integrity": "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==",
+      "dev": true,
+      "requires": {
+        "@vitest/expect": "4.1.7",
+        "@vitest/mocker": "4.1.7",
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/runner": "4.1.7",
+        "@vitest/snapshot": "4.1.7",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "dependencies": {
+        "@esbuild/aix-ppc64": {
+          "version": "0.28.0",
+          "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+          "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        },
+        "@esbuild/android-arm": {
+          "version": "0.28.0",
+          "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+          "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        },
+        "@esbuild/android-arm64": {
+          "version": "0.28.0",
+          "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+          "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        },
+        "@esbuild/android-x64": {
+          "version": "0.28.0",
+          "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+          "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        },
+        "@esbuild/darwin-arm64": {
+          "version": "0.28.0",
+          "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+          "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        },
+        "@esbuild/darwin-x64": {
+          "version": "0.28.0",
+          "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+          "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        },
+        "@esbuild/freebsd-arm64": {
+          "version": "0.28.0",
+          "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+          "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        },
+        "@esbuild/freebsd-x64": {
+          "version": "0.28.0",
+          "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+          "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        },
+        "@esbuild/linux-arm": {
+          "version": "0.28.0",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+          "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        },
+        "@esbuild/linux-arm64": {
+          "version": "0.28.0",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+          "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        },
+        "@esbuild/linux-ia32": {
+          "version": "0.28.0",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+          "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        },
+        "@esbuild/linux-loong64": {
+          "version": "0.28.0",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+          "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        },
+        "@esbuild/linux-mips64el": {
+          "version": "0.28.0",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+          "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        },
+        "@esbuild/linux-ppc64": {
+          "version": "0.28.0",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+          "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        },
+        "@esbuild/linux-riscv64": {
+          "version": "0.28.0",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+          "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        },
+        "@esbuild/linux-s390x": {
+          "version": "0.28.0",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+          "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        },
+        "@esbuild/linux-x64": {
+          "version": "0.28.0",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+          "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        },
+        "@esbuild/netbsd-arm64": {
+          "version": "0.28.0",
+          "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+          "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        },
+        "@esbuild/netbsd-x64": {
+          "version": "0.28.0",
+          "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+          "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        },
+        "@esbuild/openbsd-arm64": {
+          "version": "0.28.0",
+          "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+          "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        },
+        "@esbuild/openbsd-x64": {
+          "version": "0.28.0",
+          "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+          "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        },
+        "@esbuild/openharmony-arm64": {
+          "version": "0.28.0",
+          "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+          "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        },
+        "@esbuild/sunos-x64": {
+          "version": "0.28.0",
+          "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+          "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        },
+        "@esbuild/win32-arm64": {
+          "version": "0.28.0",
+          "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+          "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        },
+        "@esbuild/win32-ia32": {
+          "version": "0.28.0",
+          "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+          "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        },
+        "@esbuild/win32-x64": {
+          "version": "0.28.0",
+          "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+          "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        },
+        "@vitest/mocker": {
+          "version": "4.1.7",
+          "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.7.tgz",
+          "integrity": "sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==",
+          "dev": true,
+          "requires": {
+            "@vitest/spy": "4.1.7",
+            "estree-walker": "^3.0.3",
+            "magic-string": "^0.30.21"
+          }
+        },
+        "esbuild": {
+          "version": "0.28.0",
+          "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+          "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "@esbuild/aix-ppc64": "0.28.0",
+            "@esbuild/android-arm": "0.28.0",
+            "@esbuild/android-arm64": "0.28.0",
+            "@esbuild/android-x64": "0.28.0",
+            "@esbuild/darwin-arm64": "0.28.0",
+            "@esbuild/darwin-x64": "0.28.0",
+            "@esbuild/freebsd-arm64": "0.28.0",
+            "@esbuild/freebsd-x64": "0.28.0",
+            "@esbuild/linux-arm": "0.28.0",
+            "@esbuild/linux-arm64": "0.28.0",
+            "@esbuild/linux-ia32": "0.28.0",
+            "@esbuild/linux-loong64": "0.28.0",
+            "@esbuild/linux-mips64el": "0.28.0",
+            "@esbuild/linux-ppc64": "0.28.0",
+            "@esbuild/linux-riscv64": "0.28.0",
+            "@esbuild/linux-s390x": "0.28.0",
+            "@esbuild/linux-x64": "0.28.0",
+            "@esbuild/netbsd-arm64": "0.28.0",
+            "@esbuild/netbsd-x64": "0.28.0",
+            "@esbuild/openbsd-arm64": "0.28.0",
+            "@esbuild/openbsd-x64": "0.28.0",
+            "@esbuild/openharmony-arm64": "0.28.0",
+            "@esbuild/sunos-x64": "0.28.0",
+            "@esbuild/win32-arm64": "0.28.0",
+            "@esbuild/win32-ia32": "0.28.0",
+            "@esbuild/win32-x64": "0.28.0"
+          }
+        },
+        "picomatch": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+          "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+          "dev": true
+        },
+        "vite": {
+          "version": "8.0.14",
+          "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.14.tgz",
+          "integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
+          "dev": true,
+          "requires": {
+            "fsevents": "~2.3.3",
+            "lightningcss": "^1.32.0",
+            "picomatch": "^4.0.4",
+            "postcss": "^8.5.15",
+            "rolldown": "1.0.2",
+            "tinyglobby": "^0.2.16"
+          }
+        },
+        "yaml": {
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+          "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        }
+      }
+    },
+    "w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "requires": {
+        "xml-name-validator": "^5.0.0"
+      }
+    },
     "watchpack": {
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.4.tgz",
@@ -16966,6 +20487,29 @@
       "resolved": "https://registry.npmjs.org/webextension-polyfill/-/webextension-polyfill-0.12.0.tgz",
       "integrity": "sha512-97TBmpoWJEE+3nFBQ4VocyCdLKfw54rFaJ6EVQYLBCXqCIpLSZkwGgASpv4oPt9gdKCJ80RJlcmNzNn008Ag6Q=="
     },
+    "webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true
+    },
+    "whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true
+    },
+    "whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "requires": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      }
+    },
     "when": {
       "version": "3.7.7",
       "resolved": "https://registry.npmjs.org/when/-/when-3.7.7.tgz",
@@ -17011,6 +20555,16 @@
         "for-each": "^0.3.3",
         "gopd": "^1.0.1",
         "has-tostringtag": "^1.0.2"
+      }
+    },
+    "why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "requires": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
       }
     },
     "widest-line": {
@@ -17174,6 +20728,12 @@
         }
       }
     },
+    "xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true
+    },
     "xml-reader": {
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/xml-reader/-/xml-reader-2.4.3.tgz",
@@ -17204,6 +20764,12 @@
       "version": "11.0.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
       "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "dev": true
+    },
+    "xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
     },
     "y18n": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.1.2",
+        "@playwright/test": "1.60.0",
         "@testing-library/dom": "10.4.1",
         "@types/fs-extra": "11.0.4",
         "@types/node": "24.0.14",
@@ -2338,6 +2339,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@pnpm/config.env-replace": {
@@ -8940,6 +8957,53 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
@@ -14039,6 +14103,15 @@
       "integrity": "sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==",
       "dev": true
     },
+    "@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "requires": {
+        "playwright": "1.60.0"
+      }
+    },
     "@pnpm/config.env-replace": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@pnpm/config.env-replace/-/config.env-replace-1.1.0.tgz",
@@ -18448,6 +18521,31 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
       "integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==",
+      "dev": true
+    },
+    "playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "requires": {
+        "fsevents": "2.3.2",
+        "playwright-core": "1.60.0"
+      },
+      "dependencies": {
+        "fsevents": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+          "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "dev": true
     },
     "possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.1.2",
+    "@testing-library/dom": "10.4.1",
     "@types/fs-extra": "11.0.4",
     "@types/node": "24.0.14",
     "@types/react": "19.1.8",
@@ -38,6 +39,7 @@
     "esbuild": "0.25.6",
     "fs-extra": "11.3.0",
     "husky": "9.1.7",
+    "jsdom": "29.1.1",
     "lint-staged": "16.1.2",
     "nodemon": "3.1.10",
     "npm-run-all": "4.1.5",
@@ -45,6 +47,7 @@
     "sharp": "0.34.3",
     "tsx": "4.22.3",
     "typescript": "5.8.3",
+    "vitest": "4.1.7",
     "web-ext": "8.9.0"
   },
   "scripts": {
@@ -63,6 +66,8 @@
     "update-versions": "run-s update-upstream-version update-manifest-version",
     "lint": "npx @biomejs/biome check --write ./src",
     "format": "npx @biomejs/biome format --write ./src",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "prepare": "husky"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.1.2",
+    "@playwright/test": "1.60.0",
     "@testing-library/dom": "10.4.1",
     "@types/fs-extra": "11.0.4",
     "@types/node": "24.0.14",
@@ -68,6 +69,7 @@
     "format": "npx @biomejs/biome format --write ./src",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:e2e": "playwright test",
     "prepare": "husky"
   },
   "lint-staged": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from '@playwright/test';
+import path from 'path';
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 60000,
+  retries: 1,
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        viewport: { width: 1280, height: 800 },
+        launchOptions: {
+          args: [
+            `--disable-extensions-except=${path.resolve(__dirname, 'dist/chrome-edge')}`,
+            `--load-extension=${path.resolve(__dirname, 'dist/chrome-edge')}`,
+            '--no-first-run',
+            '--disable-gpu',
+          ],
+        },
+      },
+    },
+  ],
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,11 +5,13 @@ export default defineConfig({
   testDir: './e2e',
   timeout: 60000,
   retries: 1,
+  reporter: [['html', { open: 'never' }]],
   projects: [
     {
       name: 'chromium',
       use: {
         viewport: { width: 1280, height: 800 },
+        trace: 'on-first-retry',
         launchOptions: {
           args: [
             `--disable-extensions-except=${path.resolve(__dirname, 'dist/chrome-edge')}`,

--- a/src/injected-styles.css
+++ b/src/injected-styles.css
@@ -1,15 +1,15 @@
 body[data-material-icons-extension-size="sm"]
-  img[data-material-icons-extension="icon"] {
+  [data-material-icons-extension="icon"] {
   transform: scale(0.875);
 }
 
 body[data-material-icons-extension-size="lg"]
-  img[data-material-icons-extension="icon"] {
+  [data-material-icons-extension="icon"] {
   transform: scale(1.125);
 }
 
 body[data-material-icons-extension-size="xl"]
-  img[data-material-icons-extension="icon"] {
+  [data-material-icons-extension="icon"] {
   transform: scale(1.25);
 }
 

--- a/src/lib/custom-providers.test.ts
+++ b/src/lib/custom-providers.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import Browser from 'webextension-polyfill';
+import {
+  getCustomProviders,
+  addCustomProvider,
+  removeCustomProvider,
+} from './custom-providers';
+
+vi.mock('webextension-polyfill', () => ({
+  default: {
+    storage: {
+      sync: {
+        get: vi.fn(),
+        set: vi.fn(),
+      },
+    },
+  },
+}));
+
+const mockGet = Browser.storage.sync.get as ReturnType<typeof vi.fn>;
+const mockSet = Browser.storage.sync.set as ReturnType<typeof vi.fn>;
+
+describe('custom-providers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSet.mockResolvedValue(undefined);
+  });
+
+  describe('getCustomProviders', () => {
+    it('returns stored custom providers', async () => {
+      const stored = { myProvider: 'https://example.com' };
+      mockGet.mockResolvedValue({ customProviders: stored });
+
+      const result = await getCustomProviders();
+
+      expect(mockGet).toHaveBeenCalledWith('customProviders');
+      expect(result).toEqual(stored);
+    });
+
+    it('returns empty object when nothing stored', async () => {
+      mockGet.mockResolvedValue({});
+
+      const result = await getCustomProviders();
+
+      expect(mockGet).toHaveBeenCalledWith('customProviders');
+      expect(result).toEqual({});
+    });
+  });
+
+  describe('addCustomProvider', () => {
+    it('adds a new provider and calls set', async () => {
+      mockGet.mockResolvedValue({ customProviders: {} });
+
+      await addCustomProvider('newProvider', 'https://example.com');
+
+      expect(mockSet).toHaveBeenCalledWith({
+        customProviders: { newProvider: 'https://example.com' },
+      });
+    });
+
+    it('preserves existing providers when adding new one', async () => {
+      const existing = { existingProvider: 'https://existing.com' };
+      mockGet.mockResolvedValue({ customProviders: existing });
+
+      await addCustomProvider('newProvider', 'https://new.com');
+
+      expect(mockSet).toHaveBeenCalledWith({
+        customProviders: {
+          existingProvider: 'https://existing.com',
+          newProvider: 'https://new.com',
+        },
+      });
+    });
+  });
+
+  describe('removeCustomProvider', () => {
+    it('removes the specified provider and calls set', async () => {
+      const existing = { providerToRemove: 'https://remove.com' };
+      mockGet.mockResolvedValue({ customProviders: existing });
+
+      await removeCustomProvider('providerToRemove');
+
+      expect(mockSet).toHaveBeenCalledWith({
+        customProviders: {},
+      });
+    });
+
+    it('preserves other providers', async () => {
+      const existing = {
+        keepThis: 'https://keep.com',
+        removeThis: 'https://remove.com',
+      };
+      mockGet.mockResolvedValue({ customProviders: existing });
+
+      await removeCustomProvider('removeThis');
+
+      expect(mockSet).toHaveBeenCalledWith({
+        customProviders: { keepThis: 'https://keep.com' },
+      });
+    });
+  });
+});

--- a/src/lib/icon-sizes.test.ts
+++ b/src/lib/icon-sizes.test.ts
@@ -8,7 +8,7 @@ vi.mock('./user-config', () => ({
 }));
 
 import { iconSizes, initIconSizes } from './icon-sizes';
-import { getConfig, addConfigChangeListener } from './user-config';
+import { addConfigChangeListener } from './user-config';
 
 describe('icon-sizes', () => {
   beforeEach(() => {

--- a/src/lib/icon-sizes.test.ts
+++ b/src/lib/icon-sizes.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+let mockIconSize = 'md';
+
+vi.mock('./user-config', () => ({
+  getConfig: vi.fn(() => Promise.resolve(mockIconSize)),
+  addConfigChangeListener: vi.fn(),
+}));
+
+import { iconSizes, initIconSizes } from './icon-sizes';
+import { getConfig, addConfigChangeListener } from './user-config';
+
+describe('icon-sizes', () => {
+  beforeEach(() => {
+    mockIconSize = 'md';
+    document.body.removeAttribute('data-material-icons-extension-size');
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('iconSizes contains expected values', () => {
+    expect(iconSizes).toEqual(['sm', 'md', 'lg', 'xl']);
+  });
+
+  it('initIconSizes registers a DOMContentLoaded event listener', () => {
+    const spy = vi.spyOn(document, 'addEventListener');
+    initIconSizes();
+    expect(spy).toHaveBeenCalledWith(
+      'DOMContentLoaded',
+      expect.any(Function),
+      false
+    );
+  });
+
+  it('initIconSizes calls addConfigChangeListener for iconSize', () => {
+    initIconSizes();
+    expect(addConfigChangeListener).toHaveBeenCalledWith(
+      'iconSize',
+      expect.any(Function)
+    );
+    expect(addConfigChangeListener).toHaveBeenCalledWith(
+      'iconSize',
+      expect.any(Function),
+      'default'
+    );
+  });
+
+  it('after DOMContentLoaded fires, body gets the correct data-material-icons-extension-size attribute', async () => {
+    mockIconSize = 'lg';
+    initIconSizes();
+
+    const event = new Event('DOMContentLoaded');
+    document.dispatchEvent(event);
+
+    // Wait for the promise returned by getConfig to resolve
+    await vi.waitFor(() => {
+      expect(document.body.getAttribute('data-material-icons-extension-size')).toBe('lg');
+    });
+  });
+
+  it('the attribute is restored if removed from body (via MutationObserver)', async () => {
+    mockIconSize = 'xl';
+    initIconSizes();
+
+    // Fire DOMContentLoaded to set up the MutationObserver
+    const event = new Event('DOMContentLoaded');
+    document.dispatchEvent(event);
+
+    await vi.waitFor(() => {
+      expect(document.body.getAttribute('data-material-icons-extension-size')).toBe('xl');
+    });
+
+    // Remove the attribute to trigger the MutationObserver
+    document.body.removeAttribute('data-material-icons-extension-size');
+
+    await vi.waitFor(() => {
+      expect(document.body.getAttribute('data-material-icons-extension-size')).toBe('xl');
+    });
+  });
+});

--- a/src/lib/replace-icon.test.ts
+++ b/src/lib/replace-icon.test.ts
@@ -1,0 +1,753 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { replaceIconInRow, replaceElementWithIcon } from './replace-icon';
+import { Provider } from '../models';
+import { Manifest } from 'material-icon-theme';
+
+// Mock webextension-polyfill
+vi.mock('webextension-polyfill', () => ({
+  default: {
+    runtime: {
+      getURL: (name: string) => `chrome-extension://test-id/${name}`,
+    },
+  },
+}));
+
+// Mock icon-list.json
+vi.mock('../icon-list.json', () => ({
+  default: {
+    file: 'file.svg',
+    folder: 'folder.svg',
+    'folder-open': 'folder-open.svg',
+    'folder-src': 'folder-src.svg',
+    'folder-src-open': 'folder-src-open.svg',
+    'folder-git': 'folder-git.svg',
+    'folder-symlink': 'folder-symlink.svg',
+    typescript: 'typescript.svg',
+    javascript: 'javascript.svg',
+    json: 'json.svg',
+    readme: 'readme.svg',
+    'folder-node': 'folder-node.svg',
+    'folder-node-open': 'folder-node-open.svg',
+    'folder-github': 'folder-github.svg',
+    'folder-github-open': 'folder-github-open.svg',
+    'test-ts': 'test-ts.svg',
+    'folder-light-src': 'folder-light-src.svg',
+    'light-typescript': 'light-typescript.svg',
+    'custom-icon': 'custom-icon.svg',
+  },
+}));
+
+function createMockProvider(overrides: Partial<Provider> = {}): Provider {
+  return {
+    name: 'test',
+    domains: [{ host: 'test.com', test: /^test\.com$/ }],
+    selectors: {
+      row: '.row',
+      filename: '.filename',
+      icon: '.icon',
+      detect: null,
+    },
+    canSelfHost: false,
+    isCustom: false,
+    onAdd: () => {},
+    getIsDirectory: () => false,
+    getIsSubmodule: () => false,
+    getIsSymlink: () => false,
+    getIsLightTheme: () => false,
+    replaceIcon: vi.fn(),
+    transformFileName: (_row, _icon, fileName) => fileName,
+    ...overrides,
+  };
+}
+
+function createMockManifest(overrides: Partial<Manifest> = {}): Manifest {
+  return {
+    fileNames: {
+      'package.json': 'json',
+      'README.md': 'readme',
+    },
+    fileExtensions: {
+      ts: 'typescript',
+      js: 'javascript',
+      json: 'json',
+    },
+    languageIds: {},
+    folderNames: {
+      src: 'folder-src',
+      // biome-ignore lint/style/useNamingConvention: matches real folder names
+      node_modules: 'folder-node',
+      '.github': 'folder-github',
+    },
+    folderNamesExpanded: {
+      src: 'folder-src-open',
+      // biome-ignore lint/style/useNamingConvention: matches real folder names
+      node_modules: 'folder-node-open',
+      '.github': 'folder-github-open',
+    },
+    ...overrides,
+  };
+}
+
+describe('replaceIconInRow', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('should replace the icon for a TypeScript file', () => {
+    const provider = createMockProvider();
+    const manifest = createMockManifest();
+
+    document.body.innerHTML = `
+      <div class="row">
+        <span class="filename">index.ts</span>
+        <svg class="icon"></svg>
+      </div>
+    `;
+    const row = document.querySelector('.row') as HTMLElement;
+
+    replaceIconInRow(row, provider, manifest);
+
+    expect(provider.replaceIcon).toHaveBeenCalledTimes(1);
+    const newIcon = (provider.replaceIcon as ReturnType<typeof vi.fn>).mock
+      .calls[0][1] as HTMLElement;
+    expect(newIcon.getAttribute('data-material-icons-extension-iconname')).toBe(
+      'typescript.svg'
+    );
+  });
+
+  it('should replace the icon for a file matched by exact filename', () => {
+    const provider = createMockProvider();
+    const manifest = createMockManifest();
+
+    document.body.innerHTML = `
+      <div class="row">
+        <span class="filename">README.md</span>
+        <svg class="icon"></svg>
+      </div>
+    `;
+    const row = document.querySelector('.row') as HTMLElement;
+
+    replaceIconInRow(row, provider, manifest);
+
+    expect(provider.replaceIcon).toHaveBeenCalledTimes(1);
+    const newIcon = (provider.replaceIcon as ReturnType<typeof vi.fn>).mock
+      .calls[0][1] as HTMLElement;
+    expect(newIcon.getAttribute('data-material-icons-extension-iconname')).toBe(
+      'readme.svg'
+    );
+  });
+
+  it('should use folder icon for directories', () => {
+    const provider = createMockProvider({
+      getIsDirectory: () => true,
+    });
+    const manifest = createMockManifest();
+
+    document.body.innerHTML = `
+      <div class="row">
+        <span class="filename">src</span>
+        <svg class="icon"></svg>
+      </div>
+    `;
+    const row = document.querySelector('.row') as HTMLElement;
+
+    replaceIconInRow(row, provider, manifest);
+
+    expect(provider.replaceIcon).toHaveBeenCalledTimes(1);
+    const newIcon = (provider.replaceIcon as ReturnType<typeof vi.fn>).mock
+      .calls[0][1] as HTMLElement;
+    expect(newIcon.getAttribute('data-material-icons-extension-iconname')).toBe(
+      'folder-src.svg'
+    );
+  });
+
+  it('should use expanded folder icon when folder is expanded', () => {
+    const provider = createMockProvider({
+      getIsDirectory: () => true,
+      getIsExpanded: () => true,
+    });
+    const manifest = createMockManifest();
+
+    document.body.innerHTML = `
+      <div class="row">
+        <span class="filename">src</span>
+        <svg class="icon"></svg>
+      </div>
+    `;
+    const row = document.querySelector('.row') as HTMLElement;
+
+    replaceIconInRow(row, provider, manifest);
+
+    expect(provider.replaceIcon).toHaveBeenCalledTimes(1);
+    const newIcon = (provider.replaceIcon as ReturnType<typeof vi.fn>).mock
+      .calls[0][1] as HTMLElement;
+    expect(newIcon.getAttribute('data-material-icons-extension-iconname')).toBe(
+      'folder-src-open.svg'
+    );
+  });
+
+  it('should use closed folder icon when folder is collapsed', () => {
+    const provider = createMockProvider({
+      getIsDirectory: () => true,
+      getIsExpanded: () => false,
+    });
+    const manifest = createMockManifest();
+
+    document.body.innerHTML = `
+      <div class="row">
+        <span class="filename">src</span>
+        <svg class="icon"></svg>
+      </div>
+    `;
+    const row = document.querySelector('.row') as HTMLElement;
+
+    replaceIconInRow(row, provider, manifest);
+
+    expect(provider.replaceIcon).toHaveBeenCalledTimes(1);
+    const newIcon = (provider.replaceIcon as ReturnType<typeof vi.fn>).mock
+      .calls[0][1] as HTMLElement;
+    expect(newIcon.getAttribute('data-material-icons-extension-iconname')).toBe(
+      'folder-src.svg'
+    );
+  });
+
+  it('should fall back to generic folder-open.svg for unknown expanded folders', () => {
+    const provider = createMockProvider({
+      getIsDirectory: () => true,
+      getIsExpanded: () => true,
+    });
+    const manifest = createMockManifest();
+
+    document.body.innerHTML = `
+      <div class="row">
+        <span class="filename">unknown-folder</span>
+        <svg class="icon"></svg>
+      </div>
+    `;
+    const row = document.querySelector('.row') as HTMLElement;
+
+    replaceIconInRow(row, provider, manifest);
+
+    expect(provider.replaceIcon).toHaveBeenCalledTimes(1);
+    const newIcon = (provider.replaceIcon as ReturnType<typeof vi.fn>).mock
+      .calls[0][1] as HTMLElement;
+    expect(newIcon.getAttribute('data-material-icons-extension-iconname')).toBe(
+      'folder-open.svg'
+    );
+  });
+
+  it('should use folder-git icon for submodules', () => {
+    const provider = createMockProvider({
+      getIsDirectory: () => true,
+      getIsSubmodule: () => true,
+    });
+    const manifest = createMockManifest();
+
+    document.body.innerHTML = `
+      <div class="row">
+        <span class="filename">my-submodule</span>
+        <svg class="icon"></svg>
+      </div>
+    `;
+    const row = document.querySelector('.row') as HTMLElement;
+
+    replaceIconInRow(row, provider, manifest);
+
+    expect(provider.replaceIcon).toHaveBeenCalledTimes(1);
+    const newIcon = (provider.replaceIcon as ReturnType<typeof vi.fn>).mock
+      .calls[0][1] as HTMLElement;
+    expect(newIcon.getAttribute('data-material-icons-extension-iconname')).toBe(
+      'folder-git.svg'
+    );
+  });
+
+  it('should use folder-symlink icon for symlinks', () => {
+    const provider = createMockProvider({
+      getIsDirectory: () => true,
+      getIsSymlink: () => true,
+    });
+    const manifest = createMockManifest();
+
+    document.body.innerHTML = `
+      <div class="row">
+        <span class="filename">my-link</span>
+        <svg class="icon"></svg>
+      </div>
+    `;
+    const row = document.querySelector('.row') as HTMLElement;
+
+    replaceIconInRow(row, provider, manifest);
+
+    expect(provider.replaceIcon).toHaveBeenCalledTimes(1);
+    const newIcon = (provider.replaceIcon as ReturnType<typeof vi.fn>).mock
+      .calls[0][1] as HTMLElement;
+    expect(newIcon.getAttribute('data-material-icons-extension-iconname')).toBe(
+      'folder-symlink.svg'
+    );
+  });
+
+  it('should not process an icon that already has the extension attribute', () => {
+    const provider = createMockProvider();
+    const manifest = createMockManifest();
+
+    document.body.innerHTML = `
+      <div class="row">
+        <span class="filename">index.ts</span>
+        <svg class="icon" data-material-icons-extension="icon"></svg>
+      </div>
+    `;
+    const row = document.querySelector('.row') as HTMLElement;
+
+    replaceIconInRow(row, provider, manifest);
+
+    expect(provider.replaceIcon).not.toHaveBeenCalled();
+  });
+
+  it('should not process a row without a filename', () => {
+    const provider = createMockProvider();
+    const manifest = createMockManifest();
+
+    document.body.innerHTML = `
+      <div class="row">
+        <svg class="icon"></svg>
+      </div>
+    `;
+    const row = document.querySelector('.row') as HTMLElement;
+
+    replaceIconInRow(row, provider, manifest);
+
+    expect(provider.replaceIcon).not.toHaveBeenCalled();
+  });
+
+  it('should not process a row without an icon element', () => {
+    const provider = createMockProvider();
+    const manifest = createMockManifest();
+
+    document.body.innerHTML = `
+      <div class="row">
+        <span class="filename">index.ts</span>
+      </div>
+    `;
+    const row = document.querySelector('.row') as HTMLElement;
+
+    replaceIconInRow(row, provider, manifest);
+
+    expect(provider.replaceIcon).not.toHaveBeenCalled();
+  });
+
+  it('should fall back to file.svg for unknown file extensions', () => {
+    const provider = createMockProvider();
+    const manifest = createMockManifest();
+
+    document.body.innerHTML = `
+      <div class="row">
+        <span class="filename">data.xyz</span>
+        <svg class="icon"></svg>
+      </div>
+    `;
+    const row = document.querySelector('.row') as HTMLElement;
+
+    replaceIconInRow(row, provider, manifest);
+
+    expect(provider.replaceIcon).toHaveBeenCalledTimes(1);
+    const newIcon = (provider.replaceIcon as ReturnType<typeof vi.fn>).mock
+      .calls[0][1] as HTMLElement;
+    expect(newIcon.getAttribute('data-material-icons-extension-iconname')).toBe(
+      'file.svg'
+    );
+  });
+
+  it('should use transformFileName to modify the filename before lookup', () => {
+    const provider = createMockProvider({
+      transformFileName: (_row, _icon, fileName) =>
+        fileName.replace(/\s+@\s+[a-fA-F0-9]+$/, ''),
+    });
+    const manifest = createMockManifest({
+      folderNames: { 'my-submodule': 'folder-git' },
+    });
+
+    document.body.innerHTML = `
+      <div class="row">
+        <span class="filename">my-submodule @ abc123</span>
+        <svg class="icon"></svg>
+      </div>
+    `;
+    const row = document.querySelector('.row') as HTMLElement;
+
+    replaceIconInRow(row, provider, manifest);
+
+    expect(provider.replaceIcon).toHaveBeenCalledTimes(1);
+  });
+
+  it('should use customMappings when they match', () => {
+    const provider = createMockProvider({
+      getIsDirectory: () => true,
+      customMappings: [
+        {
+          match: () => true,
+          iconName: 'folder-github',
+        },
+      ],
+    });
+    const manifest = createMockManifest();
+
+    document.body.innerHTML = `
+      <div class="row">
+        <span class="filename">any-folder</span>
+        <svg class="icon"></svg>
+      </div>
+    `;
+    const row = document.querySelector('.row') as HTMLElement;
+
+    replaceIconInRow(row, provider, manifest);
+
+    expect(provider.replaceIcon).toHaveBeenCalledTimes(1);
+    const newIcon = (provider.replaceIcon as ReturnType<typeof vi.fn>).mock
+      .calls[0][1] as HTMLElement;
+    expect(newIcon.getAttribute('data-material-icons-extension-iconname')).toBe(
+      'folder-github.svg'
+    );
+  });
+});
+
+describe('replaceIconInRow - edge cases', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('should match filenames case-insensitively via lowerFileName lookup', () => {
+    const provider = createMockProvider();
+    const manifest = createMockManifest({
+      fileNames: {
+        'readme.md': 'readme',
+      },
+    });
+
+    document.body.innerHTML = `
+      <div class="row">
+        <span class="filename">README.md</span>
+        <svg class="icon"></svg>
+      </div>
+    `;
+    const row = document.querySelector('.row') as HTMLElement;
+
+    replaceIconInRow(row, provider, manifest);
+
+    expect(provider.replaceIcon).toHaveBeenCalledTimes(1);
+    const newIcon = (provider.replaceIcon as ReturnType<typeof vi.fn>).mock
+      .calls[0][1] as HTMLElement;
+    expect(newIcon.getAttribute('data-material-icons-extension-iconname')).toBe(
+      'readme.svg'
+    );
+  });
+
+  it('should match .test.ts extension before .ts for multiple extensions', () => {
+    const provider = createMockProvider();
+    const manifest = createMockManifest({
+      fileExtensions: {
+        'test.ts': 'test-ts',
+        ts: 'typescript',
+      },
+    });
+
+    document.body.innerHTML = `
+      <div class="row">
+        <span class="filename">file.test.ts</span>
+        <svg class="icon"></svg>
+      </div>
+    `;
+    const row = document.querySelector('.row') as HTMLElement;
+
+    replaceIconInRow(row, provider, manifest);
+
+    expect(provider.replaceIcon).toHaveBeenCalledTimes(1);
+    const newIcon = (provider.replaceIcon as ReturnType<typeof vi.fn>).mock
+      .calls[0][1] as HTMLElement;
+    expect(newIcon.getAttribute('data-material-icons-extension-iconname')).toBe(
+      'test-ts.svg'
+    );
+  });
+
+  it('should not parse extensions for very long filenames (>255 chars) and fall back to file.svg', () => {
+    const provider = createMockProvider();
+    const manifest = createMockManifest();
+
+    const fileName = 'a'.repeat(260) + '.ts'; // 263 chars > 255
+
+    document.body.innerHTML = `
+      <div class="row">
+        <span class="filename">${fileName}</span>
+        <svg class="icon"></svg>
+      </div>
+    `;
+    const row = document.querySelector('.row') as HTMLElement;
+
+    replaceIconInRow(row, provider, manifest);
+
+    expect(provider.replaceIcon).toHaveBeenCalledTimes(1);
+    const newIcon = (provider.replaceIcon as ReturnType<typeof vi.fn>).mock
+      .calls[0][1] as HTMLElement;
+    expect(newIcon.getAttribute('data-material-icons-extension-iconname')).toBe(
+      'file.svg'
+    );
+  });
+
+  it('should fall back to file.svg for filename with dots but no matching extension', () => {
+    const provider = createMockProvider();
+    const manifest = createMockManifest();
+
+    document.body.innerHTML = `
+      <div class="row">
+        <span class="filename">foo.bar.baz</span>
+        <svg class="icon"></svg>
+      </div>
+    `;
+    const row = document.querySelector('.row') as HTMLElement;
+
+    replaceIconInRow(row, provider, manifest);
+
+    expect(provider.replaceIcon).toHaveBeenCalledTimes(1);
+    const newIcon = (provider.replaceIcon as ReturnType<typeof vi.fn>).mock
+      .calls[0][1] as HTMLElement;
+    expect(newIcon.getAttribute('data-material-icons-extension-iconname')).toBe(
+      'file.svg'
+    );
+  });
+
+  it('should use light theme folder names when light theme is active', () => {
+    const provider = createMockProvider({
+      getIsDirectory: () => true,
+      getIsLightTheme: () => true,
+    });
+    const manifest = createMockManifest({
+      folderNames: {
+        src: 'folder-src',
+      },
+      light: {
+        folderNames: {
+          src: 'folder-light-src',
+        },
+      },
+    });
+
+    document.body.innerHTML = `
+      <div class="row">
+        <span class="filename">src</span>
+        <svg class="icon"></svg>
+      </div>
+    `;
+    const row = document.querySelector('.row') as HTMLElement;
+
+    replaceIconInRow(row, provider, manifest);
+
+    expect(provider.replaceIcon).toHaveBeenCalledTimes(1);
+    const newIcon = (provider.replaceIcon as ReturnType<typeof vi.fn>).mock
+      .calls[0][1] as HTMLElement;
+    expect(newIcon.getAttribute('data-material-icons-extension-iconname')).toBe(
+      'folder-light-src.svg'
+    );
+  });
+
+  it('should use light theme file extensions when light theme is active', () => {
+    const provider = createMockProvider({
+      getIsLightTheme: () => true,
+    });
+    const manifest = createMockManifest({
+      fileExtensions: {
+        ts: 'typescript',
+      },
+      light: {
+        fileExtensions: {
+          ts: 'light-typescript',
+        },
+      },
+    });
+
+    document.body.innerHTML = `
+      <div class="row">
+        <span class="filename">index.ts</span>
+        <svg class="icon"></svg>
+      </div>
+    `;
+    const row = document.querySelector('.row') as HTMLElement;
+
+    replaceIconInRow(row, provider, manifest);
+
+    expect(provider.replaceIcon).toHaveBeenCalledTimes(1);
+    const newIcon = (provider.replaceIcon as ReturnType<typeof vi.fn>).mock
+      .calls[0][1] as HTMLElement;
+    expect(newIcon.getAttribute('data-material-icons-extension-iconname')).toBe(
+      'light-typescript.svg'
+    );
+  });
+
+  it('should append -open to icon name for expanded folder with no folderNamesExpanded entry', () => {
+    const provider = createMockProvider({
+      getIsDirectory: () => true,
+      getIsExpanded: () => true,
+    });
+    const manifest = createMockManifest({
+      folderNames: {
+        src: 'folder-src',
+      },
+      folderNamesExpanded: {
+        // No entry for 'src' — forces fallback to `${iconName}-open`
+      },
+    });
+
+    document.body.innerHTML = `
+      <div class="row">
+        <span class="filename">src</span>
+        <svg class="icon"></svg>
+      </div>
+    `;
+    const row = document.querySelector('.row') as HTMLElement;
+
+    replaceIconInRow(row, provider, manifest);
+
+    expect(provider.replaceIcon).toHaveBeenCalledTimes(1);
+    const newIcon = (provider.replaceIcon as ReturnType<typeof vi.fn>).mock
+      .calls[0][1] as HTMLElement;
+    // The icon name becomes 'folder-src-open' which is in the icon list
+    expect(newIcon.getAttribute('data-material-icons-extension-iconname')).toBe(
+      'folder-src-open.svg'
+    );
+  });
+
+  it('should use closed folder icon when provider has no getIsExpanded method', () => {
+    const provider = createMockProvider({
+      getIsDirectory: () => true,
+      // getIsExpanded is not provided (undefined)
+    });
+    // Explicitly remove getIsExpanded
+    delete (provider as Partial<Provider>).getIsExpanded;
+
+    const manifest = createMockManifest();
+
+    document.body.innerHTML = `
+      <div class="row">
+        <span class="filename">src</span>
+        <svg class="icon"></svg>
+      </div>
+    `;
+    const row = document.querySelector('.row') as HTMLElement;
+
+    replaceIconInRow(row, provider, manifest);
+
+    expect(provider.replaceIcon).toHaveBeenCalledTimes(1);
+    const newIcon = (provider.replaceIcon as ReturnType<typeof vi.fn>).mock
+      .calls[0][1] as HTMLElement;
+    // Should not crash and should use closed folder icon
+    expect(newIcon.getAttribute('data-material-icons-extension-iconname')).toBe(
+      'folder-src.svg'
+    );
+  });
+
+  it('should normalize various whitespace types in filenames', () => {
+    const provider = createMockProvider();
+    const manifest = createMockManifest({
+      fileNames: {
+        'README.md': 'readme',
+      },
+    });
+
+    // Use tabs and multiple spaces within the filename text content
+    document.body.innerHTML = `
+      <div class="row">
+        <span class="filename">  \t README.md \t  </span>
+        <svg class="icon"></svg>
+      </div>
+    `;
+    const row = document.querySelector('.row') as HTMLElement;
+
+    replaceIconInRow(row, provider, manifest);
+
+    expect(provider.replaceIcon).toHaveBeenCalledTimes(1);
+    const newIcon = (provider.replaceIcon as ReturnType<typeof vi.fn>).mock
+      .calls[0][1] as HTMLElement;
+    expect(newIcon.getAttribute('data-material-icons-extension-iconname')).toBe(
+      'readme.svg'
+    );
+  });
+
+  it('should extract last segment from path-based filenames', () => {
+    const provider = createMockProvider();
+    const manifest = createMockManifest();
+
+    document.body.innerHTML = `
+      <div class="row">
+        <span class="filename">src/lib/index.ts</span>
+        <svg class="icon"></svg>
+      </div>
+    `;
+    const row = document.querySelector('.row') as HTMLElement;
+
+    replaceIconInRow(row, provider, manifest);
+
+    expect(provider.replaceIcon).toHaveBeenCalledTimes(1);
+    const newIcon = (provider.replaceIcon as ReturnType<typeof vi.fn>).mock
+      .calls[0][1] as HTMLElement;
+    // Should resolve 'index.ts' -> typescript extension
+    expect(newIcon.getAttribute('data-material-icons-extension-iconname')).toBe(
+      'typescript.svg'
+    );
+  });
+
+  it('should give customMappings priority over manifest entries', () => {
+    const provider = createMockProvider({
+      customMappings: [
+        {
+          match: () => true,
+          iconName: 'custom-icon',
+        },
+      ],
+    });
+    // Manifest has a match for 'package.json' -> 'json', but customMappings should win
+    const manifest = createMockManifest();
+
+    document.body.innerHTML = `
+      <div class="row">
+        <span class="filename">package.json</span>
+        <svg class="icon"></svg>
+      </div>
+    `;
+    const row = document.querySelector('.row') as HTMLElement;
+
+    replaceIconInRow(row, provider, manifest);
+
+    expect(provider.replaceIcon).toHaveBeenCalledTimes(1);
+    const newIcon = (provider.replaceIcon as ReturnType<typeof vi.fn>).mock
+      .calls[0][1] as HTMLElement;
+    expect(newIcon.getAttribute('data-material-icons-extension-iconname')).toBe(
+      'custom-icon.svg'
+    );
+  });
+});
+
+describe('replaceElementWithIcon', () => {
+  it('should create an img element with correct attributes and call provider.replaceIcon', () => {
+    const provider = createMockProvider();
+
+    document.body.innerHTML = '<svg class="icon"></svg>';
+    const iconEl = document.querySelector('.icon') as HTMLElement;
+
+    replaceElementWithIcon(iconEl, 'typescript.svg', 'index.ts', provider);
+
+    expect(provider.replaceIcon).toHaveBeenCalledTimes(1);
+    const [oldIcon, newIcon] = (
+      provider.replaceIcon as ReturnType<typeof vi.fn>
+    ).mock.calls[0];
+    expect(oldIcon).toBe(iconEl);
+    expect(newIcon.tagName).toBe('IMG');
+    expect(newIcon.getAttribute('data-material-icons-extension')).toBe('icon');
+    expect(newIcon.getAttribute('data-material-icons-extension-iconname')).toBe(
+      'typescript.svg'
+    );
+    expect(newIcon.getAttribute('data-material-icons-extension-filename')).toBe(
+      'index.ts'
+    );
+    expect(newIcon.getAttribute('src')).toBe(
+      'chrome-extension://test-id/typescript.svg'
+    );
+  });
+});

--- a/src/lib/replace-icon.ts
+++ b/src/lib/replace-icon.ts
@@ -88,8 +88,22 @@ function replaceIcon(
     );
   }
 
+  // If the folder is expanded, use the expanded variant of the icon
+  const isExpanded =
+    isDir && provider.getIsExpanded?.({ row: itemRow, icon: iconEl });
+  if (isExpanded) {
+    const lowerFN = fileName.toLowerCase();
+    const expandedName =
+      manifest.folderNamesExpanded?.[fileName] ??
+      manifest.folderNamesExpanded?.[lowerFN] ??
+      `${iconName}-open`;
+    iconName = expandedName;
+  }
+
   // get correct icon name from icon list
-  iconName = iconsListTyped[iconName] ?? (isDir ? 'folder.svg' : 'file.svg');
+  iconName =
+    iconsListTyped[iconName] ??
+    (isDir ? (isExpanded ? 'folder-open.svg' : 'folder.svg') : 'file.svg');
 
   replaceElementWithIcon(iconEl, iconName, fileName, provider);
 }

--- a/src/lib/replace-icons.test.ts
+++ b/src/lib/replace-icons.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { replaceAllIcons } from './replace-icons';
+import { Provider } from '../models';
+
+// Mock webextension-polyfill
+vi.mock('webextension-polyfill', () => ({
+  default: {
+    runtime: {
+      getURL: (name: string) => `chrome-extension://test-id/${name}`,
+    },
+  },
+}));
+
+// Mock icon-list.json
+vi.mock('../icon-list.json', () => ({
+  default: {
+    typescript: 'typescript.svg',
+    folder: 'folder.svg',
+  },
+}));
+
+// Mock selector-observer (not needed for replaceAllIcons but imported in module)
+vi.mock('selector-observer', () => ({
+  observe: vi.fn(),
+}));
+
+function createMockProvider(overrides: Partial<Provider> = {}): Provider {
+  return {
+    name: 'test',
+    domains: [{ host: 'test.com', test: /^test\.com$/ }],
+    selectors: {
+      row: '.row',
+      filename: '.filename',
+      icon: '.icon',
+      detect: null,
+    },
+    canSelfHost: false,
+    isCustom: false,
+    onAdd: () => {},
+    getIsDirectory: () => false,
+    getIsSubmodule: () => false,
+    getIsSymlink: () => false,
+    getIsLightTheme: () => false,
+    replaceIcon: vi.fn(),
+    transformFileName: (_row, _icon, fileName) => fileName,
+    ...overrides,
+  };
+}
+
+describe('replaceAllIcons', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('should call replaceIcon for each element with data-material-icons-extension-iconname', () => {
+    const provider = createMockProvider();
+
+    document.body.innerHTML = `
+      <svg data-material-icons-extension-iconname="typescript.svg" data-material-icons-extension-filename="index.ts"></svg>
+      <svg data-material-icons-extension-iconname="folder.svg" data-material-icons-extension-filename="src"></svg>
+    `;
+
+    replaceAllIcons(provider);
+
+    expect(provider.replaceIcon).toHaveBeenCalledTimes(2);
+  });
+
+  it('should not call replaceIcon for elements without iconname attribute', () => {
+    const provider = createMockProvider();
+
+    document.body.innerHTML = `
+      <svg class="octicon octicon-file"></svg>
+      <svg data-material-icons-extension="icon"></svg>
+    `;
+
+    replaceAllIcons(provider);
+
+    expect(provider.replaceIcon).not.toHaveBeenCalled();
+  });
+
+  it('should skip elements with empty iconname', () => {
+    const provider = createMockProvider();
+
+    document.body.innerHTML = `
+      <svg data-material-icons-extension-iconname="" data-material-icons-extension-filename="test.ts"></svg>
+    `;
+
+    replaceAllIcons(provider);
+
+    expect(provider.replaceIcon).not.toHaveBeenCalled();
+  });
+
+  it('should pass correct iconName and fileName to replaceElementWithIcon', () => {
+    const provider = createMockProvider();
+
+    document.body.innerHTML = `
+      <svg data-material-icons-extension-iconname="typescript.svg" data-material-icons-extension-filename="app.ts"></svg>
+    `;
+
+    replaceAllIcons(provider);
+
+    expect(provider.replaceIcon).toHaveBeenCalledTimes(1);
+    const newIcon = (provider.replaceIcon as ReturnType<typeof vi.fn>).mock
+      .calls[0][1] as HTMLElement;
+    expect(newIcon.getAttribute('data-material-icons-extension-iconname')).toBe(
+      'typescript.svg'
+    );
+    expect(newIcon.getAttribute('data-material-icons-extension-filename')).toBe(
+      'app.ts'
+    );
+    expect(newIcon.getAttribute('src')).toBe(
+      'chrome-extension://test-id/typescript.svg'
+    );
+  });
+
+  it('should work with img elements (other providers)', () => {
+    const provider = createMockProvider();
+
+    document.body.innerHTML = `
+      <img data-material-icons-extension-iconname="typescript.svg" data-material-icons-extension-filename="index.ts" src="chrome-extension://old/typescript.svg">
+    `;
+
+    replaceAllIcons(provider);
+
+    expect(provider.replaceIcon).toHaveBeenCalledTimes(1);
+  });
+
+  it('should handle missing filename attribute gracefully', () => {
+    const provider = createMockProvider();
+
+    document.body.innerHTML = `
+      <svg data-material-icons-extension-iconname="typescript.svg"></svg>
+    `;
+
+    replaceAllIcons(provider);
+
+    expect(provider.replaceIcon).toHaveBeenCalledTimes(1);
+    const newIcon = (provider.replaceIcon as ReturnType<typeof vi.fn>).mock
+      .calls[0][1] as HTMLElement;
+    expect(newIcon.getAttribute('data-material-icons-extension-filename')).toBe(
+      ''
+    );
+  });
+});

--- a/src/lib/replace-icons.ts
+++ b/src/lib/replace-icons.ts
@@ -31,7 +31,7 @@ export const observePage = (
 
 export const replaceAllIcons = (provider: Provider) => {
   document
-    .querySelectorAll('img[data-material-icons-extension-iconname]')
+    .querySelectorAll('[data-material-icons-extension-iconname]')
     .forEach((iconEl) => {
       const iconName = iconEl.getAttribute(
         'data-material-icons-extension-iconname'

--- a/src/lib/user-config.test.ts
+++ b/src/lib/user-config.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  getConfig,
+  setConfig,
+  clearConfig,
+  addConfigChangeListener,
+  hardDefaults,
+} from './user-config';
+
+const mockGet = vi.fn();
+const mockSet = vi.fn();
+const mockRemove = vi.fn();
+const mockAddListener = vi.fn();
+
+vi.mock('webextension-polyfill', () => ({
+  default: {
+    storage: {
+      sync: {
+        get: (...args: unknown[]) => mockGet(...args),
+        set: (...args: unknown[]) => mockSet(...args),
+        remove: (...args: unknown[]) => mockRemove(...args),
+      },
+      onChanged: {
+        addListener: (...args: unknown[]) => mockAddListener(...args),
+      },
+    },
+  },
+}));
+
+describe('user-config', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Set a default hostname for tests
+    Object.defineProperty(window, 'location', {
+      value: { hostname: 'github.com' },
+      writable: true,
+    });
+  });
+
+  describe('hardDefaults', () => {
+    it('has expected values', () => {
+      expect(hardDefaults).toEqual({
+        iconPack: 'react',
+        iconSize: 'md',
+        extEnabled: true,
+        fileIconBindings: {},
+        folderIconBindings: {},
+      });
+    });
+  });
+
+  describe('getConfig', () => {
+    it('returns domain-specific value when it exists', async () => {
+      mockGet.mockResolvedValue({
+        'github.com:iconPack': 'angular',
+        'default:iconPack': 'react',
+      });
+
+      const result = await getConfig('iconPack', 'github.com');
+
+      expect(result).toBe('angular');
+      expect(mockGet).toHaveBeenCalledWith({
+        'github.com:iconPack': null,
+        'default:iconPack': 'react',
+      });
+    });
+
+    it('falls back to default value when no domain-specific value exists', async () => {
+      mockGet.mockResolvedValue({
+        'default:iconPack': 'angular',
+      });
+
+      const result = await getConfig('iconPack', 'github.com');
+
+      expect(result).toBe('angular');
+    });
+
+    it('returns hardDefault when no stored value exists', async () => {
+      mockGet.mockResolvedValue({
+        'default:iconPack': 'react',
+      });
+
+      const result = await getConfig('iconPack', 'github.com');
+
+      // The hardDefault for iconPack is 'react', which is passed as the
+      // default in the keys object, so Browser.storage.sync.get returns it
+      expect(result).toBe('react');
+      expect(mockGet).toHaveBeenCalledWith({
+        'github.com:iconPack': null,
+        'default:iconPack': 'react',
+      });
+    });
+
+    it('with useDefault=false returns null when no domain-specific value', async () => {
+      mockGet.mockResolvedValue({
+        'default:iconSize': 'md',
+      });
+
+      const result = await getConfig('iconSize', 'github.com', false);
+
+      expect(result).toBeNull();
+    });
+
+    it("with domain='default' uses 'SKIP' to avoid matching itself", async () => {
+      mockGet.mockResolvedValue({
+        'default:extEnabled': true,
+      });
+
+      await getConfig('extEnabled', 'default');
+
+      expect(mockGet).toHaveBeenCalledWith({
+        'SKIP:extEnabled': null,
+        'default:extEnabled': true,
+      });
+    });
+  });
+
+  describe('setConfig', () => {
+    it('calls Browser.storage.sync.set with the correct key format', () => {
+      setConfig('iconPack', 'angular', 'github.com');
+
+      expect(mockSet).toHaveBeenCalledWith({
+        'github.com:iconPack': 'angular',
+      });
+    });
+
+    it('uses window.location.hostname as default domain', () => {
+      setConfig('iconSize', 'lg');
+
+      expect(mockSet).toHaveBeenCalledWith({
+        'github.com:iconSize': 'lg',
+      });
+    });
+  });
+
+  describe('clearConfig', () => {
+    it('calls Browser.storage.sync.remove with the correct key', () => {
+      clearConfig('iconPack', 'github.com');
+
+      expect(mockRemove).toHaveBeenCalledWith('github.com:iconPack');
+    });
+
+    it('uses window.location.hostname as default domain', () => {
+      clearConfig('extEnabled');
+
+      expect(mockRemove).toHaveBeenCalledWith('github.com:extEnabled');
+    });
+  });
+
+  describe('addConfigChangeListener', () => {
+    it('registers a listener that fires the handler when the matching config changes', () => {
+      const handler = vi.fn();
+
+      addConfigChangeListener('iconPack', handler, 'github.com');
+
+      expect(mockAddListener).toHaveBeenCalledTimes(1);
+
+      // Simulate the listener being called with matching changes
+      const listener = mockAddListener.mock.calls[0][0];
+      listener({
+        'github.com:iconPack': { newValue: 'angular', oldValue: 'react' },
+      });
+
+      expect(handler).toHaveBeenCalledWith('angular');
+    });
+
+    it('does NOT fire the handler for unrelated config changes', () => {
+      const handler = vi.fn();
+
+      addConfigChangeListener('iconPack', handler, 'github.com');
+
+      const listener = mockAddListener.mock.calls[0][0];
+
+      // Simulate a change to a different config key
+      listener({
+        'github.com:iconSize': { newValue: 'lg', oldValue: 'md' },
+      });
+
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('does NOT fire the handler when newValue is undefined', () => {
+      const handler = vi.fn();
+
+      addConfigChangeListener('iconPack', handler, 'github.com');
+
+      const listener = mockAddListener.mock.calls[0][0];
+
+      // Simulate a change where the key exists but newValue is undefined
+      listener({
+        'github.com:iconPack': { oldValue: 'react' },
+      });
+
+      expect(handler).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/models/provider.ts
+++ b/src/models/provider.ts
@@ -15,6 +15,7 @@ export type Provider = {
   getIsDirectory: (params: { row: HTMLElement; icon: HTMLElement }) => boolean;
   getIsSubmodule: (params: { row: HTMLElement; icon: HTMLElement }) => boolean;
   getIsSymlink: (params: { row: HTMLElement; icon: HTMLElement }) => boolean;
+  getIsExpanded?: (params: { row: HTMLElement; icon: HTMLElement }) => boolean;
   getIsLightTheme: () => boolean;
   replaceIcon: (oldIcon: HTMLElement, newIcon: HTMLElement) => void;
   transformFileName: (

--- a/src/providers/__snapshots__/github.snapshot.test.ts.snap
+++ b/src/providers/__snapshots__/github.snapshot.test.ts.snap
@@ -1,0 +1,140 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`GitHub provider - DOM snapshots > file icon replacement > should produce correct DOM for README.md 1`] = `
+"
+          <div class="PRIVATE_TreeView-item-visual" aria-hidden="true">
+            <svg data-component="Octicon" aria-hidden="true" focusable="false" class="octicon octicon-file" viewBox="0 0 16 16" width="16" height="16" fill="currentColor" display="inline-block" overflow="visible" style="vertical-align: text-bottom; background-image: url(&quot;chrome-extension://material-icons-ext-id/readme.svg&quot;); background-size: contain; background-repeat: no-repeat; background-position: center center;" data-material-icons-extension="icon" data-material-icons-extension-iconname="readme.svg" data-material-icons-extension-filename="README.md"></svg>
+          </div>
+          <span class="PRIVATE_TreeView-item-content-text">
+            <span>README.md</span>
+          </span>
+        "
+`;
+
+exports[`GitHub provider - DOM snapshots > file icon replacement > should produce correct DOM for a JSON file 1`] = `
+"
+          <div class="PRIVATE_TreeView-item-visual" aria-hidden="true">
+            <svg data-component="Octicon" aria-hidden="true" focusable="false" class="octicon octicon-file" viewBox="0 0 16 16" width="16" height="16" fill="currentColor" display="inline-block" overflow="visible" style="vertical-align: text-bottom; background-image: url(&quot;chrome-extension://material-icons-ext-id/json.svg&quot;); background-size: contain; background-repeat: no-repeat; background-position: center center;" data-material-icons-extension="icon" data-material-icons-extension-iconname="json.svg" data-material-icons-extension-filename="package.json"></svg>
+          </div>
+          <span class="PRIVATE_TreeView-item-content-text">
+            <span>package.json</span>
+          </span>
+        "
+`;
+
+exports[`GitHub provider - DOM snapshots > file icon replacement > should produce correct DOM for a TypeScript file 1`] = `
+"
+          <div class="PRIVATE_TreeView-item-visual" aria-hidden="true">
+            <svg data-component="Octicon" aria-hidden="true" focusable="false" class="octicon octicon-file" viewBox="0 0 16 16" width="16" height="16" fill="currentColor" display="inline-block" overflow="visible" style="vertical-align: text-bottom; background-image: url(&quot;chrome-extension://material-icons-ext-id/typescript.svg&quot;); background-size: contain; background-repeat: no-repeat; background-position: center center;" data-material-icons-extension="icon" data-material-icons-extension-iconname="typescript.svg" data-material-icons-extension-filename="index.ts"></svg>
+          </div>
+          <span class="PRIVATE_TreeView-item-content-text">
+            <span>index.ts</span>
+          </span>
+        "
+`;
+
+exports[`GitHub provider - DOM snapshots > folder icon replacement (closed) > should produce correct DOM for a closed node_modules folder 1`] = `
+"
+          <div class="PRIVATE_TreeView-item-visual" aria-hidden="true">
+            <div class="PRIVATE_TreeView-directory-icon">
+              <svg data-component="Octicon" aria-hidden="true" focusable="false" class="octicon octicon-file-directory-fill" viewBox="0 0 16 16" width="16" height="16" fill="currentColor" display="inline-block" overflow="visible" style="vertical-align: text-bottom; background-image: url(&quot;chrome-extension://material-icons-ext-id/folder-node.svg&quot;); background-size: contain; background-repeat: no-repeat; background-position: center center;" data-material-icons-extension="icon" data-material-icons-extension-iconname="folder-node.svg" data-material-icons-extension-filename="node_modules"></svg>
+            </div>
+          </div>
+          <span class="PRIVATE_TreeView-item-content-text">
+            <span>node_modules</span>
+          </span>
+        "
+`;
+
+exports[`GitHub provider - DOM snapshots > folder icon replacement (closed) > should produce correct DOM for a closed src folder 1`] = `
+"
+          <div class="PRIVATE_TreeView-item-visual" aria-hidden="true">
+            <div class="PRIVATE_TreeView-directory-icon">
+              <svg data-component="Octicon" aria-hidden="true" focusable="false" class="octicon octicon-file-directory-fill" viewBox="0 0 16 16" width="16" height="16" fill="currentColor" display="inline-block" overflow="visible" style="vertical-align: text-bottom; background-image: url(&quot;chrome-extension://material-icons-ext-id/folder-src.svg&quot;); background-size: contain; background-repeat: no-repeat; background-position: center center;" data-material-icons-extension="icon" data-material-icons-extension-iconname="folder-src.svg" data-material-icons-extension-filename="src"></svg>
+            </div>
+          </div>
+          <span class="PRIVATE_TreeView-item-content-text">
+            <span>src</span>
+          </span>
+        "
+`;
+
+exports[`GitHub provider - DOM snapshots > folder icon replacement (expanded) > should produce correct DOM for an expanded .github folder 1`] = `
+"
+          <div class="PRIVATE_TreeView-item-visual" aria-hidden="true">
+            <div class="PRIVATE_TreeView-directory-icon">
+              <svg data-component="Octicon" aria-hidden="true" focusable="false" class="octicon octicon-file-directory-open-fill" viewBox="0 0 16 16" width="16" height="16" fill="currentColor" display="inline-block" overflow="visible" style="vertical-align: text-bottom; background-image: url(&quot;chrome-extension://material-icons-ext-id/folder-github-open.svg&quot;); background-size: contain; background-repeat: no-repeat; background-position: center center;" data-material-icons-extension="icon" data-material-icons-extension-iconname="folder-github-open.svg" data-material-icons-extension-filename=".github"></svg>
+            </div>
+          </div>
+          <span class="PRIVATE_TreeView-item-content-text">
+            <span>.github</span>
+          </span>
+        "
+`;
+
+exports[`GitHub provider - DOM snapshots > folder icon replacement (expanded) > should produce correct DOM for an expanded src folder 1`] = `
+"
+          <div class="PRIVATE_TreeView-item-visual" aria-hidden="true">
+            <div class="PRIVATE_TreeView-directory-icon">
+              <svg data-component="Octicon" aria-hidden="true" focusable="false" class="octicon octicon-file-directory-open-fill" viewBox="0 0 16 16" width="16" height="16" fill="currentColor" display="inline-block" overflow="visible" style="vertical-align: text-bottom; background-image: url(&quot;chrome-extension://material-icons-ext-id/folder-src-open.svg&quot;); background-size: contain; background-repeat: no-repeat; background-position: center center;" data-material-icons-extension="icon" data-material-icons-extension-iconname="folder-src-open.svg" data-material-icons-extension-filename="src"></svg>
+            </div>
+          </div>
+          <span class="PRIVATE_TreeView-item-content-text">
+            <span>src</span>
+          </span>
+        "
+`;
+
+exports[`GitHub provider - DOM snapshots > full tree view structure > should produce correct DOM for a complete file tree 1`] = `
+"
+          <li class="PRIVATE_TreeView-item" role="treeitem" aria-expanded="true">
+            <div class="PRIVATE_TreeView-item-content">
+              <div class="PRIVATE_TreeView-item-visual" aria-hidden="true">
+                <div class="PRIVATE_TreeView-directory-icon">
+                  <svg data-component="Octicon" aria-hidden="true" focusable="false" class="octicon octicon-file-directory-open-fill" viewBox="0 0 16 16" width="16" height="16" fill="currentColor" display="inline-block" overflow="visible" style="vertical-align: text-bottom; background-image: url(&quot;chrome-extension://material-icons-ext-id/folder-src-open.svg&quot;); background-size: contain; background-repeat: no-repeat; background-position: center center;" data-material-icons-extension="icon" data-material-icons-extension-iconname="folder-src-open.svg" data-material-icons-extension-filename="src"></svg>
+                </div>
+              </div>
+              <span class="PRIVATE_TreeView-item-content-text">
+                <span>src</span>
+              </span>
+            </div>
+          </li>
+          <li class="PRIVATE_TreeView-item" role="treeitem">
+            <div class="PRIVATE_TreeView-item-content">
+              <div class="PRIVATE_TreeView-item-visual" aria-hidden="true">
+                <svg data-component="Octicon" aria-hidden="true" focusable="false" class="octicon octicon-file" viewBox="0 0 16 16" width="16" height="16" fill="currentColor" display="inline-block" overflow="visible" style="vertical-align: text-bottom; background-image: url(&quot;chrome-extension://material-icons-ext-id/typescript.svg&quot;); background-size: contain; background-repeat: no-repeat; background-position: center center;" data-material-icons-extension="icon" data-material-icons-extension-iconname="typescript.svg" data-material-icons-extension-filename="index.ts"></svg>
+              </div>
+              <span class="PRIVATE_TreeView-item-content-text">
+                <span>index.ts</span>
+              </span>
+            </div>
+          </li>
+          <li class="PRIVATE_TreeView-item" role="treeitem">
+            <div class="PRIVATE_TreeView-item-content">
+              <div class="PRIVATE_TreeView-item-visual" aria-hidden="true">
+                <svg data-component="Octicon" aria-hidden="true" focusable="false" class="octicon octicon-file" viewBox="0 0 16 16" width="16" height="16" fill="currentColor" display="inline-block" overflow="visible" style="vertical-align: text-bottom; background-image: url(&quot;chrome-extension://material-icons-ext-id/json.svg&quot;); background-size: contain; background-repeat: no-repeat; background-position: center center;" data-material-icons-extension="icon" data-material-icons-extension-iconname="json.svg" data-material-icons-extension-filename="package.json"></svg>
+              </div>
+              <span class="PRIVATE_TreeView-item-content-text">
+                <span>package.json</span>
+              </span>
+            </div>
+          </li>
+          <li class="PRIVATE_TreeView-item" role="treeitem">
+            <div class="PRIVATE_TreeView-item-content">
+              <div class="PRIVATE_TreeView-item-visual" aria-hidden="true">
+                <svg data-component="Octicon" aria-hidden="true" focusable="false" class="octicon octicon-file" viewBox="0 0 16 16" width="16" height="16" fill="currentColor" display="inline-block" overflow="visible" style="vertical-align: text-bottom; background-image: url(&quot;chrome-extension://material-icons-ext-id/git.svg&quot;); background-size: contain; background-repeat: no-repeat; background-position: center center;" data-material-icons-extension="icon" data-material-icons-extension-iconname="git.svg" data-material-icons-extension-filename=".gitignore"></svg>
+              </div>
+              <span class="PRIVATE_TreeView-item-content-text">
+                <span>.gitignore</span>
+              </span>
+            </div>
+          </li>
+        "
+`;
+
+exports[`GitHub provider - DOM snapshots > full tree view structure > should produce correct DOM for the react-directory-filename-column layout 1`] = `
+"
+          <svg data-component="Octicon" aria-hidden="true" focusable="false" class="octicon octicon-file" viewBox="0 0 16 16" width="16" height="16" fill="currentColor" display="inline-block" overflow="visible" style="vertical-align: text-bottom; background-image: url(&quot;chrome-extension://material-icons-ext-id/javascript.svg&quot;); background-size: contain; background-repeat: no-repeat; background-position: center center;" data-material-icons-extension="icon" data-material-icons-extension-iconname="javascript.svg" data-material-icons-extension-filename="app.js"></svg>
+          <a href="/repo/blob/main/app.js">app.js</a>
+        "
+`;

--- a/src/providers/azure.test.ts
+++ b/src/providers/azure.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import azure from './azure';
+
+describe('Azure provider', () => {
+  const provider = azure();
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    document.documentElement.className = '';
+  });
+
+  describe('basic properties', () => {
+    it('should have name "azure"', () => {
+      expect(provider.name).toBe('azure');
+    });
+
+    it('should have domain host "dev.azure.com"', () => {
+      expect(provider.domains[0].host).toBe('dev.azure.com');
+    });
+
+    it('should have domain host "visualstudio.com"', () => {
+      expect(provider.domains[1].host).toBe('visualstudio.com');
+    });
+
+    it('should match "dev.azure.com" with the regex', () => {
+      expect(provider.domains[0].test.test('dev.azure.com')).toBe(true);
+    });
+
+    it('should not match other domains with the first regex', () => {
+      expect(provider.domains[0].test.test('notdev.azure.com')).toBe(false);
+      expect(provider.domains[0].test.test('dev.azure.com.evil.com')).toBe(
+        false
+      );
+    });
+
+    it('should match subdomains of visualstudio.com', () => {
+      expect(provider.domains[1].test.test('myorg.visualstudio.com')).toBe(
+        true
+      );
+    });
+
+    it('should not match bare visualstudio.com without subdomain prefix', () => {
+      // The regex is /.*\.visualstudio\.com$/ which requires at least one char + dot
+      expect(provider.domains[1].test.test('visualstudio.com')).toBe(false);
+    });
+  });
+
+  describe('getIsLightTheme', () => {
+    it('should return true when computed color is rgba(0, 0, 0, 0.9)', () => {
+      // Mock getComputedStyle via defaultView
+      const mockGetComputedStyle = vi.fn().mockReturnValue({
+        getPropertyValue: (prop: string) => {
+          if (prop === 'color') return 'rgba(0, 0, 0, 0.9)';
+          return '';
+        },
+      });
+      Object.defineProperty(document, 'defaultView', {
+        value: { getComputedStyle: mockGetComputedStyle },
+        configurable: true,
+      });
+
+      expect(provider.getIsLightTheme()).toBe(true);
+    });
+
+    it('should return false when computed color is different', () => {
+      const mockGetComputedStyle = vi.fn().mockReturnValue({
+        getPropertyValue: (prop: string) => {
+          if (prop === 'color') return 'rgba(255, 255, 255, 0.9)';
+          return '';
+        },
+      });
+      Object.defineProperty(document, 'defaultView', {
+        value: { getComputedStyle: mockGetComputedStyle },
+        configurable: true,
+      });
+
+      expect(provider.getIsLightTheme()).toBe(false);
+    });
+  });
+
+  describe('getIsDirectory', () => {
+    it('should return true when icon has "repos-folder-icon" class', () => {
+      document.body.innerHTML = '<span class="repos-folder-icon"></span>';
+      const icon = document.querySelector('span') as HTMLElement;
+      expect(provider.getIsDirectory({ row: document.body, icon })).toBe(true);
+    });
+
+    it('should return false when icon does not have "repos-folder-icon" class', () => {
+      document.body.innerHTML = '<span class="some-other-icon"></span>';
+      const icon = document.querySelector('span') as HTMLElement;
+      expect(provider.getIsDirectory({ row: document.body, icon })).toBe(false);
+    });
+  });
+
+  describe('getIsSubmodule', () => {
+    it('should always return false', () => {
+      const row = document.createElement('div');
+      const icon = document.createElement('span');
+      expect(provider.getIsSubmodule({ row, icon })).toBe(false);
+    });
+  });
+
+  describe('getIsSymlink', () => {
+    it('should return true when icon has "ms-Icon--PageArrowRight" class', () => {
+      document.body.innerHTML =
+        '<span class="ms-Icon--PageArrowRight"></span>';
+      const icon = document.querySelector('span') as HTMLElement;
+      expect(provider.getIsSymlink({ row: document.body, icon })).toBe(true);
+    });
+
+    it('should return false when icon does not have "ms-Icon--PageArrowRight" class', () => {
+      document.body.innerHTML = '<span class="some-icon"></span>';
+      const icon = document.querySelector('span') as HTMLElement;
+      expect(provider.getIsSymlink({ row: document.body, icon })).toBe(false);
+    });
+  });
+
+  describe('replaceIcon', () => {
+    it('should set display to inline-flex on the new SVG', () => {
+      document.body.innerHTML =
+        '<div><span class="icon-margin"><i class="old-icon"></i></span></div>';
+      const svgEl = document.querySelector('.icon-margin') as HTMLElement;
+      const newSVG = document.createElement('img');
+
+      provider.replaceIcon(svgEl, newSVG);
+
+      expect(newSVG.style.display).toBe('inline-flex');
+    });
+
+    it('should set height and width to 1rem on the new SVG', () => {
+      document.body.innerHTML =
+        '<div><span class="icon-margin"><i class="old-icon"></i></span></div>';
+      const svgEl = document.querySelector('.icon-margin') as HTMLElement;
+      const newSVG = document.createElement('img');
+
+      provider.replaceIcon(svgEl, newSVG);
+
+      expect(newSVG.style.height).toBe('1rem');
+      expect(newSVG.style.width).toBe('1rem');
+    });
+
+    it('should add the HIDE_PSEUDO_CLASS to the container element', () => {
+      document.body.innerHTML =
+        '<div><span class="icon-margin"><i class="old-icon"></i></span></div>';
+      const svgEl = document.querySelector('.icon-margin') as HTMLElement;
+      const newSVG = document.createElement('img');
+
+      provider.replaceIcon(svgEl, newSVG);
+
+      expect(
+        svgEl.classList.contains('material-icons-exension-hide-pseudo')
+      ).toBe(true);
+    });
+
+    it('should not add HIDE_PSEUDO_CLASS twice', () => {
+      document.body.innerHTML =
+        '<div><span class="icon-margin material-icons-exension-hide-pseudo"><i class="old-icon"></i></span></div>';
+      const svgEl = document.querySelector('.icon-margin') as HTMLElement;
+      const newSVG = document.createElement('img');
+
+      provider.replaceIcon(svgEl, newSVG);
+
+      const classes = Array.from(svgEl.classList);
+      const count = classes.filter(
+        (c) => c === 'material-icons-exension-hide-pseudo'
+      ).length;
+      expect(count).toBe(1);
+    });
+
+    it('should replace the child node if container has children', () => {
+      document.body.innerHTML =
+        '<div><span class="icon-margin"><i class="old-icon"></i></span></div>';
+      const svgEl = document.querySelector('.icon-margin') as HTMLElement;
+      const newSVG = document.createElement('img');
+
+      provider.replaceIcon(svgEl, newSVG);
+
+      expect(svgEl.contains(newSVG)).toBe(true);
+      expect(svgEl.querySelector('.old-icon')).toBeNull();
+    });
+
+    it('should append the new icon if container has no children', () => {
+      document.body.innerHTML =
+        '<div><span class="icon-margin"></span></div>';
+      const svgEl = document.querySelector('.icon-margin') as HTMLElement;
+      const newSVG = document.createElement('img');
+
+      provider.replaceIcon(svgEl, newSVG);
+
+      expect(svgEl.contains(newSVG)).toBe(true);
+      expect(svgEl.childNodes.length).toBe(1);
+    });
+  });
+
+  describe('onAdd', () => {
+    it('should set up a MutationObserver on the row', () => {
+      const row = document.createElement('tr');
+      document.body.appendChild(row);
+      const callback = vi.fn();
+
+      provider.onAdd(row, callback);
+
+      // Trigger a mutation that is NOT an IMG addition
+      const span = document.createElement('span');
+      row.appendChild(span);
+
+      // MutationObserver is async, give it a tick
+      return new Promise<void>((resolve) => {
+        setTimeout(() => {
+          expect(callback).toHaveBeenCalled();
+          resolve();
+        }, 0);
+      });
+    });
+
+    it('should NOT call callback when the mutation adds an IMG node (extension mutation)', () => {
+      const row = document.createElement('tr');
+      document.body.appendChild(row);
+      const callback = vi.fn();
+
+      provider.onAdd(row, callback);
+
+      // Trigger a mutation that IS an IMG addition
+      const img = document.createElement('img');
+      row.appendChild(img);
+
+      return new Promise<void>((resolve) => {
+        setTimeout(() => {
+          expect(callback).not.toHaveBeenCalled();
+          resolve();
+        }, 0);
+      });
+    });
+  });
+
+  describe('transformFileName', () => {
+    it('should pass through filename unchanged', () => {
+      const row = document.createElement('div');
+      const icon = document.createElement('span');
+      expect(provider.transformFileName(row, icon, 'index.ts')).toBe(
+        'index.ts'
+      );
+    });
+  });
+});

--- a/src/providers/bitbucket.test.ts
+++ b/src/providers/bitbucket.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import bitbucket from './bitbucket';
+
+describe('Bitbucket provider', () => {
+  const provider = bitbucket();
+
+  it('should have name "bitbucket"', () => {
+    expect(provider.name).toBe('bitbucket');
+  });
+
+  describe('domains', () => {
+    it('should have bitbucket.org as host', () => {
+      expect(provider.domains[0].host).toBe('bitbucket.org');
+    });
+
+    it('should match bitbucket.org with regex', () => {
+      expect(provider.domains[0].test.test('bitbucket.org')).toBe(true);
+    });
+
+    it('should not match other hosts with regex', () => {
+      expect(provider.domains[0].test.test('notbitbucket.org')).toBe(false);
+      expect(provider.domains[0].test.test('bitbucket.org.evil.com')).toBe(
+        false
+      );
+    });
+  });
+
+  describe('getIsLightTheme', () => {
+    it('should return true when no dark mode is available', () => {
+      expect(provider.getIsLightTheme()).toBe(true);
+    });
+
+    it('should return true regardless of data-color-mode attribute', () => {
+      document.documentElement.setAttribute('data-color-mode', 'dark');
+      expect(provider.getIsLightTheme()).toBe(true);
+      document.documentElement.removeAttribute('data-color-mode');
+    });
+  });
+
+  describe('getIsDirectory', () => {
+    it('should detect directory from parent aria-label', () => {
+      document.body.innerHTML =
+        '<a aria-label="Directory,"><svg class="icon"></svg></a>';
+      const icon = document.querySelector('svg') as unknown as HTMLElement;
+      expect(provider.getIsDirectory({ row: document.body, icon })).toBe(true);
+    });
+
+    it('should return false for non-directory', () => {
+      document.body.innerHTML =
+        '<a aria-label="File,"><svg class="icon"></svg></a>';
+      const icon = document.querySelector('svg') as unknown as HTMLElement;
+      expect(provider.getIsDirectory({ row: document.body, icon })).toBe(
+        false
+      );
+    });
+  });
+
+  describe('getIsSubmodule', () => {
+    it('should detect submodule from parent aria-label', () => {
+      document.body.innerHTML =
+        '<a aria-label="Submodule,"><svg class="icon"></svg></a>';
+      const icon = document.querySelector('svg') as unknown as HTMLElement;
+      expect(provider.getIsSubmodule({ row: document.body, icon })).toBe(true);
+    });
+
+    it('should return false for non-submodule', () => {
+      document.body.innerHTML =
+        '<a aria-label="File,"><svg class="icon"></svg></a>';
+      const icon = document.querySelector('svg') as unknown as HTMLElement;
+      expect(provider.getIsSubmodule({ row: document.body, icon })).toBe(
+        false
+      );
+    });
+  });
+
+  describe('getIsSymlink', () => {
+    it('should always return false', () => {
+      const icon = document.createElement('span');
+      expect(provider.getIsSymlink({ row: document.body, icon })).toBe(false);
+    });
+  });
+
+  describe('replaceIcon', () => {
+    beforeEach(() => {
+      document.body.innerHTML = '';
+    });
+
+    it('should set overflow, pointerEvents, maxHeight, maxWidth, verticalAlign styles', () => {
+      document.body.innerHTML = `
+        <div>
+          <svg class="icon" viewBox="0 0 16 16"></svg>
+        </div>
+      `;
+      const svgEl = document.querySelector('svg') as unknown as HTMLElement;
+      const newSVG = document.createElementNS(
+        'http://www.w3.org/2000/svg',
+        'svg'
+      ) as unknown as HTMLElement;
+
+      provider.replaceIcon(svgEl, newSVG);
+
+      expect(newSVG.style.overflow).toBe('hidden');
+      expect(newSVG.style.pointerEvents).toBe('none');
+      expect(newSVG.style.maxHeight).toBe('100%');
+      expect(newSVG.style.maxWidth).toBe('100%');
+      expect(newSVG.style.verticalAlign).toBe('bottom');
+    });
+
+    it('should copy attributes except src and data-material-icons-extension-*', () => {
+      document.body.innerHTML = `
+        <div>
+          <svg class="icon" viewBox="0 0 16 16" src="old.svg" data-material-icons-extension="icon" aria-hidden="true"></svg>
+        </div>
+      `;
+      const svgEl = document.querySelector('svg') as unknown as HTMLElement;
+      const newSVG = document.createElementNS(
+        'http://www.w3.org/2000/svg',
+        'svg'
+      ) as unknown as HTMLElement;
+
+      provider.replaceIcon(svgEl, newSVG);
+
+      expect(newSVG.getAttribute('class')).toBe('icon');
+      expect(newSVG.getAttribute('viewBox')).toBe('0 0 16 16');
+      expect(newSVG.getAttribute('aria-hidden')).toBe('true');
+      expect(newSVG.getAttribute('src')).toBeNull();
+      expect(
+        newSVG.getAttribute('data-material-icons-extension')
+      ).toBeNull();
+    });
+
+    it('should replace the element in DOM', () => {
+      document.body.innerHTML = `
+        <div class="container">
+          <svg class="old-icon" viewBox="0 0 16 16"></svg>
+        </div>
+      `;
+      const container = document.querySelector('.container') as HTMLElement;
+      const svgEl = document.querySelector('svg') as unknown as HTMLElement;
+      const newSVG = document.createElementNS(
+        'http://www.w3.org/2000/svg',
+        'svg'
+      ) as unknown as HTMLElement;
+
+      provider.replaceIcon(svgEl, newSVG);
+
+      expect(container.contains(svgEl)).toBe(false);
+      expect(container.contains(newSVG)).toBe(true);
+    });
+  });
+
+  describe('transformFileName', () => {
+    it('should pass through filename unchanged', () => {
+      const row = document.createElement('tr');
+      const icon = document.createElement('svg') as unknown as HTMLElement;
+      expect(provider.transformFileName(row, icon, 'index.ts')).toBe(
+        'index.ts'
+      );
+    });
+  });
+});

--- a/src/providers/forgejo.test.ts
+++ b/src/providers/forgejo.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import forgejo from './forgejo';
+
+describe('Forgejo provider', () => {
+  const provider = forgejo();
+
+  it('should have name "forgejo"', () => {
+    expect(provider.name).toBe('forgejo');
+  });
+
+  describe('domains', () => {
+    it('should have codeberg.org as host', () => {
+      expect(provider.domains[0].host).toBe('codeberg.org');
+    });
+
+    it('should match codeberg.org with test regex', () => {
+      expect(provider.domains[0].test.test('codeberg.org')).toBe(true);
+    });
+
+    it('should not match other hosts', () => {
+      expect(provider.domains[0].test.test('notcodeberg.org')).toBe(false);
+    });
+  });
+
+  it('should allow self-hosting', () => {
+    expect(provider.canSelfHost).toBe(true);
+  });
+
+  describe('getIsLightTheme', () => {
+    it('should always return false', () => {
+      expect(provider.getIsLightTheme()).toBe(false);
+    });
+  });
+
+  describe('getIsDirectory', () => {
+    it('should return true when icon has octicon-file-directory-fill class', () => {
+      document.body.innerHTML =
+        '<svg class="octicon-file-directory-fill"></svg>';
+      const icon = document.querySelector('svg') as unknown as HTMLElement;
+      expect(provider.getIsDirectory({ row: document.body, icon })).toBe(true);
+    });
+
+    it('should return false when icon lacks directory class', () => {
+      document.body.innerHTML = '<svg class="octicon-file"></svg>';
+      const icon = document.querySelector('svg') as unknown as HTMLElement;
+      expect(provider.getIsDirectory({ row: document.body, icon })).toBe(
+        false
+      );
+    });
+  });
+
+  describe('getIsSubmodule', () => {
+    it('should return true when icon has octicon-file-submodule class', () => {
+      document.body.innerHTML = '<svg class="octicon-file-submodule"></svg>';
+      const icon = document.querySelector('svg') as unknown as HTMLElement;
+      expect(provider.getIsSubmodule({ row: document.body, icon })).toBe(true);
+    });
+
+    it('should return false when icon lacks submodule class', () => {
+      document.body.innerHTML = '<svg class="octicon-file"></svg>';
+      const icon = document.querySelector('svg') as unknown as HTMLElement;
+      expect(provider.getIsSubmodule({ row: document.body, icon })).toBe(
+        false
+      );
+    });
+  });
+
+  describe('getIsSymlink', () => {
+    it('should return true when icon has octicon-file-symlink-file class', () => {
+      document.body.innerHTML =
+        '<svg class="octicon-file-symlink-file"></svg>';
+      const icon = document.querySelector('svg') as unknown as HTMLElement;
+      expect(provider.getIsSymlink({ row: document.body, icon })).toBe(true);
+    });
+
+    it('should return false when icon lacks symlink class', () => {
+      document.body.innerHTML = '<svg class="octicon-file"></svg>';
+      const icon = document.querySelector('svg') as unknown as HTMLElement;
+      expect(provider.getIsSymlink({ row: document.body, icon })).toBe(false);
+    });
+  });
+
+  describe('replaceIcon', () => {
+    beforeEach(() => {
+      document.body.innerHTML = '';
+    });
+
+    it('should copy attributes except src and data-material-icons-extension-*', () => {
+      document.body.innerHTML =
+        '<div><svg class="octicon" viewBox="0 0 16 16" width="16" height="16"></svg></div>';
+      const svgEl = document.querySelector('svg') as unknown as HTMLElement;
+      const newSVG = document.createElement('svg') as unknown as HTMLElement;
+      newSVG.setAttribute('src', 'icon.svg');
+      newSVG.setAttribute('data-material-icons-extension', 'icon');
+      newSVG.setAttribute(
+        'data-material-icons-extension-iconname',
+        'typescript.svg'
+      );
+
+      provider.replaceIcon(svgEl, newSVG);
+
+      expect(newSVG.getAttribute('class')).toBe('octicon');
+      expect(newSVG.getAttribute('viewBox')).toBe('0 0 16 16');
+      expect(newSVG.getAttribute('width')).toBe('16');
+      expect(newSVG.getAttribute('height')).toBe('16');
+    });
+
+    it('should not copy src attribute to newSVG', () => {
+      document.body.innerHTML =
+        '<div><svg src="old.svg" class="octicon"></svg></div>';
+      const svgEl = document.querySelector('svg') as unknown as HTMLElement;
+      const newSVG = document.createElement('svg') as unknown as HTMLElement;
+
+      provider.replaceIcon(svgEl, newSVG);
+
+      expect(newSVG.getAttribute('src')).toBeNull();
+    });
+
+    it('should not copy data-material-icons-extension-* attributes to newSVG', () => {
+      document.body.innerHTML =
+        '<div><svg data-material-icons-extension="icon" data-material-icons-extension-iconname="old.svg" class="octicon"></svg></div>';
+      const svgEl = document.querySelector('svg') as unknown as HTMLElement;
+      const newSVG = document.createElement('svg') as unknown as HTMLElement;
+
+      provider.replaceIcon(svgEl, newSVG);
+
+      expect(newSVG.getAttribute('data-material-icons-extension')).toBeNull();
+      expect(
+        newSVG.getAttribute('data-material-icons-extension-iconname')
+      ).toBeNull();
+      expect(newSVG.getAttribute('class')).toBe('octicon');
+    });
+
+    it('should replace element in DOM via parentNode.replaceChild', () => {
+      document.body.innerHTML =
+        '<div class="container"><svg class="octicon"></svg></div>';
+      const container = document.querySelector('.container') as HTMLElement;
+      const svgEl = document.querySelector('svg') as unknown as HTMLElement;
+      const newSVG = document.createElement('svg') as unknown as HTMLElement;
+
+      provider.replaceIcon(svgEl, newSVG);
+
+      expect(container.contains(newSVG)).toBe(true);
+      expect(container.contains(svgEl)).toBe(false);
+    });
+  });
+
+  describe('transformFileName', () => {
+    it('should pass through normal filenames unchanged', () => {
+      const row = document.createElement('div');
+      const icon = document.createElement('svg');
+      expect(provider.transformFileName(row, icon, 'index.ts')).toBe(
+        'index.ts'
+      );
+    });
+
+    it('should transform Source code archive names when row has .archive-link', () => {
+      const row = document.createElement('div');
+      row.innerHTML = '<a class="archive-link" href="#"></a>';
+      const icon = document.createElement('svg');
+      expect(
+        provider.transformFileName(row, icon, 'Source code (zip)')
+      ).toBe('Source code.zip');
+    });
+
+    it('should not transform Source code names without .archive-link', () => {
+      const row = document.createElement('div');
+      const icon = document.createElement('svg');
+      expect(
+        provider.transformFileName(row, icon, 'Source code (zip)')
+      ).toBe('Source code (zip)');
+    });
+  });
+});

--- a/src/providers/gitea.test.ts
+++ b/src/providers/gitea.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import gitea from './gitea';
+
+describe('Gitea provider', () => {
+  const provider = gitea();
+
+  it('should have name "gitea"', () => {
+    expect(provider.name).toBe('gitea');
+  });
+
+  describe('domains', () => {
+    it('should have gitea.com as host', () => {
+      expect(provider.domains[0].host).toBe('gitea.com');
+    });
+
+    it('should match gitea.com with test regex', () => {
+      expect(provider.domains[0].test.test('gitea.com')).toBe(true);
+    });
+
+    it('should not match other hosts', () => {
+      expect(provider.domains[0].test.test('notgitea.com')).toBe(false);
+    });
+  });
+
+  it('should allow self-hosting', () => {
+    expect(provider.canSelfHost).toBe(true);
+  });
+
+  describe('getIsLightTheme', () => {
+    it('should always return false', () => {
+      expect(provider.getIsLightTheme()).toBe(false);
+    });
+  });
+
+  describe('getIsDirectory', () => {
+    it('should return true when icon has octicon-file-directory-fill class', () => {
+      document.body.innerHTML =
+        '<svg class="octicon-file-directory-fill"></svg>';
+      const icon = document.querySelector('svg') as unknown as HTMLElement;
+      expect(provider.getIsDirectory({ row: document.body, icon })).toBe(true);
+    });
+
+    it('should return false when icon lacks directory class', () => {
+      document.body.innerHTML = '<svg class="octicon-file"></svg>';
+      const icon = document.querySelector('svg') as unknown as HTMLElement;
+      expect(provider.getIsDirectory({ row: document.body, icon })).toBe(
+        false
+      );
+    });
+  });
+
+  describe('getIsSubmodule', () => {
+    it('should return true when icon has octicon-file-submodule class', () => {
+      document.body.innerHTML = '<svg class="octicon-file-submodule"></svg>';
+      const icon = document.querySelector('svg') as unknown as HTMLElement;
+      expect(provider.getIsSubmodule({ row: document.body, icon })).toBe(true);
+    });
+
+    it('should return false when icon lacks submodule class', () => {
+      document.body.innerHTML = '<svg class="octicon-file"></svg>';
+      const icon = document.querySelector('svg') as unknown as HTMLElement;
+      expect(provider.getIsSubmodule({ row: document.body, icon })).toBe(
+        false
+      );
+    });
+  });
+
+  describe('getIsSymlink', () => {
+    it('should return true when icon has octicon-file-symlink-file class', () => {
+      document.body.innerHTML =
+        '<svg class="octicon-file-symlink-file"></svg>';
+      const icon = document.querySelector('svg') as unknown as HTMLElement;
+      expect(provider.getIsSymlink({ row: document.body, icon })).toBe(true);
+    });
+
+    it('should return false when icon lacks symlink class', () => {
+      document.body.innerHTML = '<svg class="octicon-file"></svg>';
+      const icon = document.querySelector('svg') as unknown as HTMLElement;
+      expect(provider.getIsSymlink({ row: document.body, icon })).toBe(false);
+    });
+  });
+
+  describe('replaceIcon', () => {
+    beforeEach(() => {
+      document.body.innerHTML = '';
+    });
+
+    it('should copy attributes except src and data-material-icons-extension-*', () => {
+      document.body.innerHTML =
+        '<div><svg class="octicon" viewBox="0 0 16 16" width="16" height="16"></svg></div>';
+      const svgEl = document.querySelector('svg') as unknown as HTMLElement;
+      const newSVG = document.createElement('svg') as unknown as HTMLElement;
+      newSVG.setAttribute('src', 'icon.svg');
+      newSVG.setAttribute('data-material-icons-extension', 'icon');
+      newSVG.setAttribute(
+        'data-material-icons-extension-iconname',
+        'typescript.svg'
+      );
+
+      provider.replaceIcon(svgEl, newSVG);
+
+      expect(newSVG.getAttribute('class')).toBe('octicon');
+      expect(newSVG.getAttribute('viewBox')).toBe('0 0 16 16');
+      expect(newSVG.getAttribute('width')).toBe('16');
+      expect(newSVG.getAttribute('height')).toBe('16');
+    });
+
+    it('should not copy src attribute to newSVG', () => {
+      document.body.innerHTML =
+        '<div><svg src="old.svg" class="octicon"></svg></div>';
+      const svgEl = document.querySelector('svg') as unknown as HTMLElement;
+      const newSVG = document.createElement('svg') as unknown as HTMLElement;
+
+      provider.replaceIcon(svgEl, newSVG);
+
+      expect(newSVG.getAttribute('src')).toBeNull();
+    });
+
+    it('should not copy data-material-icons-extension-* attributes to newSVG', () => {
+      document.body.innerHTML =
+        '<div><svg data-material-icons-extension="icon" data-material-icons-extension-iconname="old.svg" class="octicon"></svg></div>';
+      const svgEl = document.querySelector('svg') as unknown as HTMLElement;
+      const newSVG = document.createElement('svg') as unknown as HTMLElement;
+
+      provider.replaceIcon(svgEl, newSVG);
+
+      expect(newSVG.getAttribute('data-material-icons-extension')).toBeNull();
+      expect(
+        newSVG.getAttribute('data-material-icons-extension-iconname')
+      ).toBeNull();
+      expect(newSVG.getAttribute('class')).toBe('octicon');
+    });
+
+    it('should replace element in DOM via parentNode.replaceChild', () => {
+      document.body.innerHTML =
+        '<div class="container"><svg class="octicon"></svg></div>';
+      const container = document.querySelector('.container') as HTMLElement;
+      const svgEl = document.querySelector('svg') as unknown as HTMLElement;
+      const newSVG = document.createElement('svg') as unknown as HTMLElement;
+
+      provider.replaceIcon(svgEl, newSVG);
+
+      expect(container.contains(newSVG)).toBe(true);
+      expect(container.contains(svgEl)).toBe(false);
+    });
+  });
+
+  describe('transformFileName', () => {
+    it('should pass through normal filenames unchanged', () => {
+      const row = document.createElement('div');
+      const icon = document.createElement('svg');
+      expect(provider.transformFileName(row, icon, 'index.ts')).toBe(
+        'index.ts'
+      );
+    });
+
+    it('should transform Source code archive names when row has .archive-link', () => {
+      const row = document.createElement('div');
+      row.innerHTML = '<a class="archive-link" href="#"></a>';
+      const icon = document.createElement('svg');
+      expect(
+        provider.transformFileName(row, icon, 'Source code (zip)')
+      ).toBe('Source code.zip');
+    });
+
+    it('should not transform Source code names without .archive-link', () => {
+      const row = document.createElement('div');
+      const icon = document.createElement('svg');
+      expect(
+        provider.transformFileName(row, icon, 'Source code (zip)')
+      ).toBe('Source code (zip)');
+    });
+  });
+});

--- a/src/providers/gitee.test.ts
+++ b/src/providers/gitee.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import gitee from './gitee';
+
+describe('Gitee provider', () => {
+  const provider = gitee();
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  describe('basic properties', () => {
+    it('should have name "gitee"', () => {
+      expect(provider.name).toBe('gitee');
+    });
+
+    it('should have domain host "gitee.com"', () => {
+      expect(provider.domains[0].host).toBe('gitee.com');
+    });
+
+    it('should match "gitee.com" with the regex', () => {
+      expect(provider.domains[0].test.test('gitee.com')).toBe(true);
+    });
+
+    it('should not match other domains', () => {
+      expect(provider.domains[0].test.test('notgitee.com')).toBe(false);
+      expect(provider.domains[0].test.test('gitee.com.evil.com')).toBe(false);
+    });
+
+    it('should not be able to self host', () => {
+      expect(provider.canSelfHost).toBe(false);
+    });
+
+    it('should not be custom', () => {
+      expect(provider.isCustom).toBe(false);
+    });
+  });
+
+  describe('getIsLightTheme', () => {
+    it('should always return true (no dark theme available)', () => {
+      expect(provider.getIsLightTheme()).toBe(true);
+    });
+  });
+
+  describe('getIsDirectory', () => {
+    it('should return true when icon has "icon-folders" class', () => {
+      document.body.innerHTML = '<i class="iconfont icon-folders"></i>';
+      const icon = document.querySelector('i') as HTMLElement;
+      expect(provider.getIsDirectory({ row: document.body, icon })).toBe(true);
+    });
+
+    it('should return false when icon does not have "icon-folders" class', () => {
+      document.body.innerHTML = '<i class="iconfont icon-file"></i>';
+      const icon = document.querySelector('i') as HTMLElement;
+      expect(provider.getIsDirectory({ row: document.body, icon })).toBe(false);
+    });
+  });
+
+  describe('getIsSubmodule', () => {
+    it('should return true when icon has "icon-submodule" class', () => {
+      document.body.innerHTML = '<i class="iconfont icon-submodule"></i>';
+      const icon = document.querySelector('i') as HTMLElement;
+      expect(provider.getIsSubmodule({ row: document.body, icon })).toBe(true);
+    });
+
+    it('should return false when icon does not have "icon-submodule" class', () => {
+      document.body.innerHTML = '<i class="iconfont icon-file"></i>';
+      const icon = document.querySelector('i') as HTMLElement;
+      expect(provider.getIsSubmodule({ row: document.body, icon })).toBe(false);
+    });
+  });
+
+  describe('getIsSymlink', () => {
+    it('should return true when icon has "icon-file-shortcut" class', () => {
+      document.body.innerHTML = '<i class="iconfont icon-file-shortcut"></i>';
+      const icon = document.querySelector('i') as HTMLElement;
+      expect(provider.getIsSymlink({ row: document.body, icon })).toBe(true);
+    });
+
+    it('should return false when icon does not have "icon-file-shortcut" class', () => {
+      document.body.innerHTML = '<i class="iconfont icon-file"></i>';
+      const icon = document.querySelector('i') as HTMLElement;
+      expect(provider.getIsSymlink({ row: document.body, icon })).toBe(false);
+    });
+  });
+
+  describe('replaceIcon', () => {
+    it('should copy attributes from old element to new element', () => {
+      document.body.innerHTML =
+        '<div><i class="iconfont icon-file" data-custom="value"></i></div>';
+      const svgEl = document.querySelector('i') as HTMLElement;
+      const newSVG = document.createElement('img') as unknown as HTMLElement;
+
+      provider.replaceIcon(svgEl, newSVG);
+
+      expect(newSVG.getAttribute('class')).toBe('iconfont icon-file');
+      expect(newSVG.getAttribute('data-custom')).toBe('value');
+    });
+
+    it('should NOT copy "src" attribute', () => {
+      document.body.innerHTML = '<div><i src="old.svg"></i></div>';
+      const svgEl = document.querySelector('i') as HTMLElement;
+      const newSVG = document.createElement('img') as unknown as HTMLElement;
+
+      provider.replaceIcon(svgEl, newSVG);
+
+      expect(newSVG.getAttribute('src')).toBeNull();
+    });
+
+    it('should NOT copy "data-material-icons-extension-*" attributes', () => {
+      document.body.innerHTML =
+        '<div><i data-material-icons-extension="icon" data-material-icons-extension-iconname="test.svg"></i></div>';
+      const svgEl = document.querySelector('i') as HTMLElement;
+      const newSVG = document.createElement('img') as unknown as HTMLElement;
+
+      provider.replaceIcon(svgEl, newSVG);
+
+      expect(
+        newSVG.getAttribute('data-material-icons-extension')
+      ).toBeNull();
+      expect(
+        newSVG.getAttribute('data-material-icons-extension-iconname')
+      ).toBeNull();
+    });
+
+    it('should set height to 28px and width to 18px', () => {
+      document.body.innerHTML = '<div><i class="iconfont"></i></div>';
+      const svgEl = document.querySelector('i') as HTMLElement;
+      const newSVG = document.createElement('img') as unknown as HTMLElement;
+
+      provider.replaceIcon(svgEl, newSVG);
+
+      expect(newSVG.style.height).toBe('28px');
+      expect(newSVG.style.width).toBe('18px');
+    });
+
+    it('should replace the old element in the DOM via parentNode.replaceChild', () => {
+      document.body.innerHTML =
+        '<div class="container"><i class="iconfont icon-file"></i></div>';
+      const container = document.querySelector('.container') as HTMLElement;
+      const svgEl = document.querySelector('i') as HTMLElement;
+      const newSVG = document.createElement('img') as unknown as HTMLElement;
+
+      provider.replaceIcon(svgEl, newSVG);
+
+      expect(container.contains(svgEl)).toBe(false);
+      expect(container.contains(newSVG)).toBe(true);
+    });
+  });
+
+  describe('onAdd', () => {
+    it('should be a no-op function', () => {
+      const row = document.createElement('div');
+      const callback = () => {};
+      // Should not throw
+      expect(() => provider.onAdd(row, callback)).not.toThrow();
+    });
+  });
+
+  describe('transformFileName', () => {
+    it('should pass through normal filenames unchanged', () => {
+      const row = document.createElement('div');
+      const icon = document.createElement('i');
+      expect(provider.transformFileName(row, icon, 'index.ts')).toBe(
+        'index.ts'
+      );
+    });
+
+    it('should transform "Source code (zip)" to "Source code.zip" when row has "item" class', () => {
+      const row = document.createElement('div');
+      row.classList.add('item');
+      const icon = document.createElement('i');
+      expect(
+        provider.transformFileName(row, icon, 'Source code (zip)')
+      ).toBe('Source code.zip');
+    });
+
+    it('should transform "Source code (tar.gz)" to "Source code.tar.gz" when row has "item" class', () => {
+      const row = document.createElement('div');
+      row.classList.add('item');
+      const icon = document.createElement('i');
+      expect(
+        provider.transformFileName(row, icon, 'Source code (tar.gz)')
+      ).toBe('Source code.tar.gz');
+    });
+
+    it('should NOT transform "Source code (zip)" when row does not have "item" class', () => {
+      const row = document.createElement('div');
+      const icon = document.createElement('i');
+      expect(
+        provider.transformFileName(row, icon, 'Source code (zip)')
+      ).toBe('Source code (zip)');
+    });
+
+    it('should NOT transform a filename that does not include "Source code"', () => {
+      const row = document.createElement('div');
+      row.classList.add('item');
+      const icon = document.createElement('i');
+      expect(provider.transformFileName(row, icon, 'archive (zip)')).toBe(
+        'archive (zip)'
+      );
+    });
+  });
+});

--- a/src/providers/github.snapshot.test.ts
+++ b/src/providers/github.snapshot.test.ts
@@ -1,0 +1,358 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import github from './github';
+import { replaceIconInRow } from '../lib/replace-icon';
+import { Manifest } from 'material-icon-theme';
+
+// Mock webextension-polyfill
+vi.mock('webextension-polyfill', () => ({
+  default: {
+    runtime: {
+      getURL: (name: string) =>
+        `chrome-extension://material-icons-ext-id/${name}`,
+    },
+  },
+}));
+
+// Mock icon-list.json with common icons
+vi.mock('../icon-list.json', () => ({
+  default: {
+    file: 'file.svg',
+    folder: 'folder.svg',
+    'folder-open': 'folder-open.svg',
+    'folder-src': 'folder-src.svg',
+    'folder-src-open': 'folder-src-open.svg',
+    typescript: 'typescript.svg',
+    javascript: 'javascript.svg',
+    json: 'json.svg',
+    readme: 'readme.svg',
+    git: 'git.svg',
+    'folder-github': 'folder-github.svg',
+    'folder-github-open': 'folder-github-open.svg',
+    'folder-node': 'folder-node.svg',
+    'folder-node-open': 'folder-node-open.svg',
+  },
+}));
+
+const manifest: Manifest = {
+  fileNames: {
+    'package.json': 'json',
+    'README.md': 'readme',
+    '.gitignore': 'git',
+  },
+  fileExtensions: {
+    ts: 'typescript',
+    js: 'javascript',
+    json: 'json',
+  },
+  languageIds: {},
+  folderNames: {
+    src: 'folder-src',
+    // biome-ignore lint/style/useNamingConvention: real folder name
+    node_modules: 'folder-node',
+    '.github': 'folder-github',
+  },
+  folderNamesExpanded: {
+    src: 'folder-src-open',
+    // biome-ignore lint/style/useNamingConvention: real folder name
+    node_modules: 'folder-node-open',
+    '.github': 'folder-github-open',
+  },
+};
+
+const provider = github();
+
+describe('GitHub provider - DOM snapshots', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  describe('file icon replacement', () => {
+    it('should produce correct DOM for a TypeScript file', () => {
+      document.body.innerHTML = `
+        <div class="PRIVATE_TreeView-item-content">
+          <div class="PRIVATE_TreeView-item-visual" aria-hidden="true">
+            <svg data-component="Octicon" aria-hidden="true" focusable="false"
+              class="octicon octicon-file" viewBox="0 0 16 16" width="16" height="16"
+              fill="currentColor" display="inline-block" overflow="visible"
+              style="vertical-align: text-bottom;">
+              <path d="M2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0 1 13.25 16h-9.5A1.75 1.75 0 0 1 2 14.25Zm1.75-.25a.25.25 0 0 0-.25.25v12.5c0 .138.112.25.25.25h9.5a.25.25 0 0 0 .25-.25V6h-2.75A1.75 1.75 0 0 1 9 4.25V1.5Zm6.75.062V4.25c0 .138.112.25.25.25h2.688l-.011-.013-2.914-2.914-.013-.011Z"></path>
+            </svg>
+          </div>
+          <span class="PRIVATE_TreeView-item-content-text">
+            <span>index.ts</span>
+          </span>
+        </div>
+      `;
+
+      const row = document.querySelector(
+        '.PRIVATE_TreeView-item-content'
+      ) as HTMLElement;
+      replaceIconInRow(row, provider, manifest);
+
+      expect(row.innerHTML).toMatchSnapshot();
+    });
+
+    it('should produce correct DOM for a JSON file', () => {
+      document.body.innerHTML = `
+        <div class="PRIVATE_TreeView-item-content">
+          <div class="PRIVATE_TreeView-item-visual" aria-hidden="true">
+            <svg data-component="Octicon" aria-hidden="true" focusable="false"
+              class="octicon octicon-file" viewBox="0 0 16 16" width="16" height="16"
+              fill="currentColor" display="inline-block" overflow="visible"
+              style="vertical-align: text-bottom;">
+              <path d="M2 1.75C2 .784 2.784 0 3.75 0h6.586..."></path>
+            </svg>
+          </div>
+          <span class="PRIVATE_TreeView-item-content-text">
+            <span>package.json</span>
+          </span>
+        </div>
+      `;
+
+      const row = document.querySelector(
+        '.PRIVATE_TreeView-item-content'
+      ) as HTMLElement;
+      replaceIconInRow(row, provider, manifest);
+
+      expect(row.innerHTML).toMatchSnapshot();
+    });
+
+    it('should produce correct DOM for README.md', () => {
+      document.body.innerHTML = `
+        <div class="PRIVATE_TreeView-item-content">
+          <div class="PRIVATE_TreeView-item-visual" aria-hidden="true">
+            <svg data-component="Octicon" aria-hidden="true" focusable="false"
+              class="octicon octicon-file" viewBox="0 0 16 16" width="16" height="16"
+              fill="currentColor" display="inline-block" overflow="visible"
+              style="vertical-align: text-bottom;">
+              <path d="M2 1.75C2 .784..."></path>
+            </svg>
+          </div>
+          <span class="PRIVATE_TreeView-item-content-text">
+            <span>README.md</span>
+          </span>
+        </div>
+      `;
+
+      const row = document.querySelector(
+        '.PRIVATE_TreeView-item-content'
+      ) as HTMLElement;
+      replaceIconInRow(row, provider, manifest);
+
+      expect(row.innerHTML).toMatchSnapshot();
+    });
+  });
+
+  describe('folder icon replacement (closed)', () => {
+    it('should produce correct DOM for a closed src folder', () => {
+      document.body.innerHTML = `
+        <div class="PRIVATE_TreeView-item-content">
+          <div class="PRIVATE_TreeView-item-visual" aria-hidden="true">
+            <div class="PRIVATE_TreeView-directory-icon">
+              <svg data-component="Octicon" aria-hidden="true" focusable="false"
+                class="octicon octicon-file-directory-fill" viewBox="0 0 16 16" width="16" height="16"
+                fill="currentColor" display="inline-block" overflow="visible"
+                style="vertical-align: text-bottom;">
+                <path d="M1.75 1A1.75 1.75 0 0 0 0 2.75v10.5C0 14.216.784 15 1.75 15h12.5A1.75 1.75 0 0 0 16 13.25v-8.5A1.75 1.75 0 0 0 14.25 3H7.5a.25.25 0 0 1-.2-.1l-.9-1.2C6.07 1.26 5.55 1 5 1H1.75Z"></path>
+              </svg>
+            </div>
+          </div>
+          <span class="PRIVATE_TreeView-item-content-text">
+            <span>src</span>
+          </span>
+        </div>
+      `;
+
+      const row = document.querySelector(
+        '.PRIVATE_TreeView-item-content'
+      ) as HTMLElement;
+      replaceIconInRow(row, provider, manifest);
+
+      expect(row.innerHTML).toMatchSnapshot();
+    });
+
+    it('should produce correct DOM for a closed node_modules folder', () => {
+      document.body.innerHTML = `
+        <div class="PRIVATE_TreeView-item-content">
+          <div class="PRIVATE_TreeView-item-visual" aria-hidden="true">
+            <div class="PRIVATE_TreeView-directory-icon">
+              <svg data-component="Octicon" aria-hidden="true" focusable="false"
+                class="octicon octicon-file-directory-fill" viewBox="0 0 16 16" width="16" height="16"
+                fill="currentColor" display="inline-block" overflow="visible"
+                style="vertical-align: text-bottom;">
+                <path d="M1.75 1A1.75 1.75 0 0 0 0 2.75v10.5C0 14.216..."></path>
+              </svg>
+            </div>
+          </div>
+          <span class="PRIVATE_TreeView-item-content-text">
+            <span>node_modules</span>
+          </span>
+        </div>
+      `;
+
+      const row = document.querySelector(
+        '.PRIVATE_TreeView-item-content'
+      ) as HTMLElement;
+      replaceIconInRow(row, provider, manifest);
+
+      expect(row.innerHTML).toMatchSnapshot();
+    });
+  });
+
+  describe('folder icon replacement (expanded)', () => {
+    it('should produce correct DOM for an expanded src folder', () => {
+      document.body.innerHTML = `
+        <div class="PRIVATE_TreeView-item-content">
+          <div class="PRIVATE_TreeView-item-visual" aria-hidden="true">
+            <div class="PRIVATE_TreeView-directory-icon">
+              <svg data-component="Octicon" aria-hidden="true" focusable="false"
+                class="octicon octicon-file-directory-open-fill" viewBox="0 0 16 16" width="16" height="16"
+                fill="currentColor" display="inline-block" overflow="visible"
+                style="vertical-align: text-bottom;">
+                <path d="M.513 1.513A1.75 1.75 0 0 1 1.75 1h3.5c.55 0 1.07.26 1.4.7l.9 1.2a.25.25 0 0 0 .2.1h6.5A1.75 1.75 0 0 1 16 4.75v8.5A1.75 1.75 0 0 1 14.25 15H1.75A1.75 1.75 0 0 1 0 13.25V2.75c0-.464.184-.91.513-1.237Z"></path>
+              </svg>
+            </div>
+          </div>
+          <span class="PRIVATE_TreeView-item-content-text">
+            <span>src</span>
+          </span>
+        </div>
+      `;
+
+      const row = document.querySelector(
+        '.PRIVATE_TreeView-item-content'
+      ) as HTMLElement;
+      replaceIconInRow(row, provider, manifest);
+
+      expect(row.innerHTML).toMatchSnapshot();
+    });
+
+    it('should produce correct DOM for an expanded .github folder', () => {
+      document.body.innerHTML = `
+        <div class="PRIVATE_TreeView-item-content">
+          <div class="PRIVATE_TreeView-item-visual" aria-hidden="true">
+            <div class="PRIVATE_TreeView-directory-icon">
+              <svg data-component="Octicon" aria-hidden="true" focusable="false"
+                class="octicon octicon-file-directory-open-fill" viewBox="0 0 16 16" width="16" height="16"
+                fill="currentColor" display="inline-block" overflow="visible"
+                style="vertical-align: text-bottom;">
+                <path d="M.513 1.513A1.75 1.75 0 0 1 1.75 1h3.5c.55 0 1.07..."></path>
+              </svg>
+            </div>
+          </div>
+          <span class="PRIVATE_TreeView-item-content-text">
+            <span>.github</span>
+          </span>
+        </div>
+      `;
+
+      const row = document.querySelector(
+        '.PRIVATE_TreeView-item-content'
+      ) as HTMLElement;
+      replaceIconInRow(row, provider, manifest);
+
+      expect(row.innerHTML).toMatchSnapshot();
+    });
+  });
+
+  describe('full tree view structure', () => {
+    it('should produce correct DOM for a complete file tree', () => {
+      document.body.innerHTML = `
+        <ul role="tree" aria-label="Files" class="prc-TreeView-TreeViewRootUlStyles">
+          <li class="PRIVATE_TreeView-item" role="treeitem" aria-expanded="true">
+            <div class="PRIVATE_TreeView-item-content">
+              <div class="PRIVATE_TreeView-item-visual" aria-hidden="true">
+                <div class="PRIVATE_TreeView-directory-icon">
+                  <svg data-component="Octicon" aria-hidden="true" focusable="false"
+                    class="octicon octicon-file-directory-open-fill" viewBox="0 0 16 16" width="16" height="16"
+                    fill="currentColor" display="inline-block" overflow="visible"
+                    style="vertical-align: text-bottom;">
+                    <path d="M.513 1.513A1.75..."></path>
+                  </svg>
+                </div>
+              </div>
+              <span class="PRIVATE_TreeView-item-content-text">
+                <span>src</span>
+              </span>
+            </div>
+          </li>
+          <li class="PRIVATE_TreeView-item" role="treeitem">
+            <div class="PRIVATE_TreeView-item-content">
+              <div class="PRIVATE_TreeView-item-visual" aria-hidden="true">
+                <svg data-component="Octicon" aria-hidden="true" focusable="false"
+                  class="octicon octicon-file" viewBox="0 0 16 16" width="16" height="16"
+                  fill="currentColor" display="inline-block" overflow="visible"
+                  style="vertical-align: text-bottom;">
+                  <path d="M2 1.75C2 .784..."></path>
+                </svg>
+              </div>
+              <span class="PRIVATE_TreeView-item-content-text">
+                <span>index.ts</span>
+              </span>
+            </div>
+          </li>
+          <li class="PRIVATE_TreeView-item" role="treeitem">
+            <div class="PRIVATE_TreeView-item-content">
+              <div class="PRIVATE_TreeView-item-visual" aria-hidden="true">
+                <svg data-component="Octicon" aria-hidden="true" focusable="false"
+                  class="octicon octicon-file" viewBox="0 0 16 16" width="16" height="16"
+                  fill="currentColor" display="inline-block" overflow="visible"
+                  style="vertical-align: text-bottom;">
+                  <path d="M2 1.75C2 .784..."></path>
+                </svg>
+              </div>
+              <span class="PRIVATE_TreeView-item-content-text">
+                <span>package.json</span>
+              </span>
+            </div>
+          </li>
+          <li class="PRIVATE_TreeView-item" role="treeitem">
+            <div class="PRIVATE_TreeView-item-content">
+              <div class="PRIVATE_TreeView-item-visual" aria-hidden="true">
+                <svg data-component="Octicon" aria-hidden="true" focusable="false"
+                  class="octicon octicon-file" viewBox="0 0 16 16" width="16" height="16"
+                  fill="currentColor" display="inline-block" overflow="visible"
+                  style="vertical-align: text-bottom;">
+                  <path d="M2 1.75C2 .784..."></path>
+                </svg>
+              </div>
+              <span class="PRIVATE_TreeView-item-content-text">
+                <span>.gitignore</span>
+              </span>
+            </div>
+          </li>
+        </ul>
+      `;
+
+      // Process each row
+      const rows = document.querySelectorAll('.PRIVATE_TreeView-item-content');
+      for (const row of rows) {
+        replaceIconInRow(row as HTMLElement, provider, manifest);
+      }
+
+      const tree = document.querySelector('[role="tree"]') as HTMLElement;
+      expect(tree.innerHTML).toMatchSnapshot();
+    });
+
+    it('should produce correct DOM for the react-directory-filename-column layout', () => {
+      document.body.innerHTML = `
+        <div class="react-directory-filename-column">
+          <svg data-component="Octicon" aria-hidden="true" focusable="false"
+            class="octicon octicon-file" viewBox="0 0 16 16" width="16" height="16"
+            fill="currentColor" display="inline-block" overflow="visible"
+            style="vertical-align: text-bottom;">
+            <path d="M2 1.75C2 .784..."></path>
+          </svg>
+          <a href="/repo/blob/main/app.js">app.js</a>
+        </div>
+      `;
+
+      const row = document.querySelector(
+        '.react-directory-filename-column'
+      ) as HTMLElement;
+      replaceIconInRow(row, provider, manifest);
+
+      expect(row.innerHTML).toMatchSnapshot();
+    });
+  });
+});

--- a/src/providers/github.test.ts
+++ b/src/providers/github.test.ts
@@ -1,0 +1,342 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import github from './github';
+
+describe('GitHub provider', () => {
+  const provider = github();
+
+  describe('replaceIcon', () => {
+    beforeEach(() => {
+      document.body.innerHTML = '';
+    });
+
+    it('should set background-image on the original SVG', () => {
+      document.body.innerHTML = `
+        <svg class="octicon octicon-file" viewBox="0 0 16 16" width="16" height="16">
+          <path d="M2 1.75C2..."></path>
+        </svg>
+      `;
+      const svgEl = document.querySelector('svg') as unknown as HTMLElement;
+      const newIcon = document.createElement('img');
+      newIcon.setAttribute('src', 'chrome-extension://id/typescript.svg');
+      newIcon.setAttribute('data-material-icons-extension', 'icon');
+      newIcon.setAttribute(
+        'data-material-icons-extension-iconname',
+        'typescript.svg'
+      );
+      newIcon.setAttribute(
+        'data-material-icons-extension-filename',
+        'index.ts'
+      );
+
+      provider.replaceIcon(svgEl, newIcon);
+
+      expect(svgEl.style.backgroundImage).toBe(
+        'url("chrome-extension://id/typescript.svg")'
+      );
+      expect(svgEl.style.backgroundSize).toBe('contain');
+      expect(svgEl.style.backgroundRepeat).toBe('no-repeat');
+      expect(svgEl.style.backgroundPosition).toBe('center center');
+    });
+
+    it('should clear SVG inner content (paths)', () => {
+      document.body.innerHTML = `
+        <svg class="octicon octicon-file" viewBox="0 0 16 16">
+          <path d="M2 1.75C2..."></path>
+          <path d="M5 3..."></path>
+        </svg>
+      `;
+      const svgEl = document.querySelector('svg') as unknown as HTMLElement;
+      const newIcon = document.createElement('img');
+      newIcon.setAttribute('src', 'chrome-extension://id/typescript.svg');
+      newIcon.setAttribute('data-material-icons-extension', 'icon');
+      newIcon.setAttribute(
+        'data-material-icons-extension-iconname',
+        'typescript.svg'
+      );
+      newIcon.setAttribute(
+        'data-material-icons-extension-filename',
+        'index.ts'
+      );
+
+      provider.replaceIcon(svgEl, newIcon);
+
+      expect(svgEl.innerHTML).toBe('');
+    });
+
+    it('should mark the SVG with extension data attributes', () => {
+      document.body.innerHTML = `
+        <svg class="octicon octicon-file" viewBox="0 0 16 16">
+          <path d="M2 1.75C2..."></path>
+        </svg>
+      `;
+      const svgEl = document.querySelector('svg') as unknown as HTMLElement;
+      const newIcon = document.createElement('img');
+      newIcon.setAttribute('src', 'chrome-extension://id/folder-src.svg');
+      newIcon.setAttribute('data-material-icons-extension', 'icon');
+      newIcon.setAttribute(
+        'data-material-icons-extension-iconname',
+        'folder-src.svg'
+      );
+      newIcon.setAttribute('data-material-icons-extension-filename', 'src');
+
+      provider.replaceIcon(svgEl, newIcon);
+
+      expect(svgEl.getAttribute('data-material-icons-extension')).toBe('icon');
+      expect(
+        svgEl.getAttribute('data-material-icons-extension-iconname')
+      ).toBe('folder-src.svg');
+      expect(
+        svgEl.getAttribute('data-material-icons-extension-filename')
+      ).toBe('src');
+    });
+
+    it('should reset display style (in case it was previously hidden)', () => {
+      document.body.innerHTML = `
+        <svg class="octicon octicon-file" style="display: none;">
+          <path d="M2 1.75C2..."></path>
+        </svg>
+      `;
+      const svgEl = document.querySelector('svg') as unknown as HTMLElement;
+      const newIcon = document.createElement('img');
+      newIcon.setAttribute('src', 'chrome-extension://id/typescript.svg');
+      newIcon.setAttribute('data-material-icons-extension', 'icon');
+      newIcon.setAttribute(
+        'data-material-icons-extension-iconname',
+        'typescript.svg'
+      );
+      newIcon.setAttribute(
+        'data-material-icons-extension-filename',
+        'index.ts'
+      );
+
+      provider.replaceIcon(svgEl, newIcon);
+
+      expect(svgEl.style.display).toBe('');
+    });
+
+    it('should update background when called again on same element', () => {
+      document.body.innerHTML = `
+        <svg class="octicon octicon-file" viewBox="0 0 16 16">
+          <path d="M2 1.75C2..."></path>
+        </svg>
+      `;
+      const svgEl = document.querySelector('svg') as unknown as HTMLElement;
+
+      // First call
+      const newIcon1 = document.createElement('img');
+      newIcon1.setAttribute('src', 'chrome-extension://id/folder-src.svg');
+      newIcon1.setAttribute('data-material-icons-extension', 'icon');
+      newIcon1.setAttribute(
+        'data-material-icons-extension-iconname',
+        'folder-src.svg'
+      );
+      newIcon1.setAttribute('data-material-icons-extension-filename', 'src');
+      provider.replaceIcon(svgEl, newIcon1);
+
+      // Second call (simulating expand)
+      const newIcon2 = document.createElement('img');
+      newIcon2.setAttribute(
+        'src',
+        'chrome-extension://id/folder-src-open.svg'
+      );
+      newIcon2.setAttribute('data-material-icons-extension', 'icon');
+      newIcon2.setAttribute(
+        'data-material-icons-extension-iconname',
+        'folder-src-open.svg'
+      );
+      newIcon2.setAttribute('data-material-icons-extension-filename', 'src');
+      provider.replaceIcon(svgEl, newIcon2);
+
+      expect(svgEl.style.backgroundImage).toBe(
+        'url("chrome-extension://id/folder-src-open.svg")'
+      );
+      expect(
+        svgEl.getAttribute('data-material-icons-extension-iconname')
+      ).toBe('folder-src-open.svg');
+    });
+
+    it('should copy fgColor class to adjacent link', () => {
+      document.body.innerHTML = `
+        <div>
+          <span>
+            <svg class="octicon octicon-file-added fgColor-done" viewBox="0 0 16 16">
+              <path d="M2..."></path>
+            </svg>
+          </span>
+          <span><a href="#">file.ts</a></span>
+        </div>
+      `;
+      const svgEl = document.querySelector('svg') as unknown as HTMLElement;
+      const newIcon = document.createElement('img');
+      newIcon.setAttribute('src', 'chrome-extension://id/typescript.svg');
+      newIcon.setAttribute('data-material-icons-extension', 'icon');
+      newIcon.setAttribute(
+        'data-material-icons-extension-iconname',
+        'typescript.svg'
+      );
+      newIcon.setAttribute(
+        'data-material-icons-extension-filename',
+        'file.ts'
+      );
+
+      provider.replaceIcon(svgEl, newIcon);
+
+      const link = document.querySelector('a') as HTMLElement;
+      expect(link.classList.contains('fgColor-done')).toBe(true);
+    });
+
+    it('should not copy fgColor-muted class to adjacent link', () => {
+      document.body.innerHTML = `
+        <div>
+          <span>
+            <svg class="octicon octicon-file fgColor-muted" viewBox="0 0 16 16">
+              <path d="M2..."></path>
+            </svg>
+          </span>
+          <span><a href="#">file.ts</a></span>
+        </div>
+      `;
+      const svgEl = document.querySelector('svg') as unknown as HTMLElement;
+      const newIcon = document.createElement('img');
+      newIcon.setAttribute('src', 'chrome-extension://id/typescript.svg');
+      newIcon.setAttribute('data-material-icons-extension', 'icon');
+      newIcon.setAttribute(
+        'data-material-icons-extension-iconname',
+        'typescript.svg'
+      );
+      newIcon.setAttribute(
+        'data-material-icons-extension-filename',
+        'file.ts'
+      );
+
+      provider.replaceIcon(svgEl, newIcon);
+
+      const link = document.querySelector('a') as HTMLElement;
+      expect(link.classList.contains('fgColor-muted')).toBe(false);
+    });
+
+    it('should not add elements to the DOM (background approach only)', () => {
+      document.body.innerHTML = `
+        <div class="container">
+          <svg class="octicon octicon-file" viewBox="0 0 16 16">
+            <path d="M2 1.75C2..."></path>
+          </svg>
+        </div>
+      `;
+      const container = document.querySelector('.container') as HTMLElement;
+      const svgEl = document.querySelector('svg') as unknown as HTMLElement;
+      const newIcon = document.createElement('img');
+      newIcon.setAttribute('src', 'chrome-extension://id/typescript.svg');
+      newIcon.setAttribute('data-material-icons-extension', 'icon');
+      newIcon.setAttribute(
+        'data-material-icons-extension-iconname',
+        'typescript.svg'
+      );
+      newIcon.setAttribute(
+        'data-material-icons-extension-filename',
+        'index.ts'
+      );
+
+      provider.replaceIcon(svgEl, newIcon);
+
+      // Should only have the original SVG, no img element added
+      expect(container.querySelectorAll('img').length).toBe(0);
+      expect(container.querySelectorAll('svg').length).toBe(1);
+    });
+  });
+
+  describe('getIsDirectory', () => {
+    it('should detect directory from aria-label', () => {
+      document.body.innerHTML =
+        '<svg aria-label="Directory" class="octicon"></svg>';
+      const icon = document.querySelector('svg') as unknown as HTMLElement;
+      expect(
+        provider.getIsDirectory({ row: document.body, icon })
+      ).toBe(true);
+    });
+
+    it('should detect directory from octicon-file-directory-fill class', () => {
+      document.body.innerHTML =
+        '<svg class="octicon octicon-file-directory-fill"></svg>';
+      const icon = document.querySelector('svg') as unknown as HTMLElement;
+      expect(
+        provider.getIsDirectory({ row: document.body, icon })
+      ).toBe(true);
+    });
+
+    it('should detect directory from octicon-file-directory-open-fill class', () => {
+      document.body.innerHTML =
+        '<svg class="octicon octicon-file-directory-open-fill"></svg>';
+      const icon = document.querySelector('svg') as unknown as HTMLElement;
+      expect(
+        provider.getIsDirectory({ row: document.body, icon })
+      ).toBe(true);
+    });
+
+    it('should return false for file icons', () => {
+      document.body.innerHTML = '<svg class="octicon octicon-file"></svg>';
+      const icon = document.querySelector('svg') as unknown as HTMLElement;
+      expect(
+        provider.getIsDirectory({ row: document.body, icon })
+      ).toBe(false);
+    });
+  });
+
+  describe('getIsExpanded', () => {
+    it('should return true for open directory icon', () => {
+      document.body.innerHTML =
+        '<svg class="octicon octicon-file-directory-open-fill"></svg>';
+      const icon = document.querySelector('svg') as unknown as HTMLElement;
+      expect(
+        provider.getIsExpanded!({ row: document.body, icon })
+      ).toBe(true);
+    });
+
+    it('should return false for closed directory icon', () => {
+      document.body.innerHTML =
+        '<svg class="octicon octicon-file-directory-fill"></svg>';
+      const icon = document.querySelector('svg') as unknown as HTMLElement;
+      expect(
+        provider.getIsExpanded!({ row: document.body, icon })
+      ).toBe(false);
+    });
+  });
+
+  describe('getIsSubmodule', () => {
+    it('should detect submodule from class', () => {
+      document.body.innerHTML =
+        '<svg class="octicon octicon-file-submodule"></svg>';
+      const icon = document.querySelector('svg') as unknown as HTMLElement;
+      expect(
+        provider.getIsSubmodule({ row: document.body, icon })
+      ).toBe(true);
+    });
+  });
+
+  describe('transformFileName', () => {
+    it('should strip submodule SHA from filename', () => {
+      const row = document.createElement('div');
+      const icon = document.createElement('svg');
+      expect(
+        provider.transformFileName(row, icon, 'my-module @ abc1234')
+      ).toBe('my-module');
+    });
+
+    it('should transform Source code archive names', () => {
+      const row = document.createElement('div');
+      row.classList.add('Box-row');
+      const icon = document.createElement('svg');
+      expect(
+        provider.transformFileName(row, icon, 'Source code (zip)')
+      ).toBe('Source code.zip');
+    });
+
+    it('should pass through normal filenames', () => {
+      const row = document.createElement('div');
+      const icon = document.createElement('svg');
+      expect(provider.transformFileName(row, icon, 'index.ts')).toBe(
+        'index.ts'
+      );
+    });
+  });
+});

--- a/src/providers/github.ts
+++ b/src/providers/github.ts
@@ -63,41 +63,39 @@ export default function github(): Provider {
     getIsSymlink: ({ icon }) =>
       icon.classList.contains('octicon-file-symlink-file'),
     replaceIcon: (svgEl, newSVG) => {
-      svgEl
-        .getAttributeNames()
-        .forEach(
-          (attr) =>
-            attr !== 'src' &&
-            !/^data-material-icons-extension/.test(attr) &&
-            newSVG.setAttribute(attr, svgEl.getAttribute(attr) ?? '')
-        );
+      const iconUrl = newSVG.getAttribute('src') ?? '';
+      const iconName =
+        newSVG.getAttribute('data-material-icons-extension-iconname') ?? '';
+      const fileName =
+        newSVG.getAttribute('data-material-icons-extension-filename') ?? '';
 
-      // Remove semantic classes to avoid conflicts with Refined GitHub (#142)
-      newSVG.classList.remove(
-        'octicon-file-added',
-        'octicon-file-removed',
-        'octicon-file-moved',
-        'octicon-file-diff'
-      );
-
+      // If the previous sibling is an old-style <img> icon from this extension,
+      // remove it (migration from the old approach).
       const prevEl = svgEl.previousElementSibling;
       if (prevEl?.getAttribute('data-material-icons-extension') === 'icon') {
-        newSVG.replaceWith(prevEl);
+        prevEl.remove();
       }
-      // If the icon to replace is an icon from this extension, replace it with the new icon
-      else if (svgEl.getAttribute('data-material-icons-extension') === 'icon') {
-        svgEl.replaceWith(newSVG);
-      }
-      // If neither of the above, prepend the new icon in front of the original icon.
-      // If we remove the icon, GitHub code view crashes when you navigate through the
-      // tree view. Instead, we hide it via CSS (adjacent sibling rule in injected-styles).
-      // Using CSS instead of inline styles ensures cloned nodes don't carry hidden state.
-      // https://github.com/material-extensions/material-icons-browser-extension/pull/66
+
+      // Clear the SVG's internal paths/shapes so nothing renders on top
+      // of our background icon. This keeps the original element in the DOM
+      // (avoiding GitHub SPA crashes) while visually replacing its content.
+      svgEl.innerHTML = '';
+
+      // Apply the material icon as a background image on the existing SVG.
+      // This avoids adding new elements, copying classes, or conflicting
+      // with other extensions like Refined GitHub.
+      // https://github.com/material-extensions/material-icons-browser-extension/issues/65#issuecomment-1538427263
       // https://github.com/material-extensions/material-icons-browser-extension/issues/142
-      else {
-        svgEl.style.display = 'none';
-        svgEl.before(newSVG);
-      }
+      svgEl.style.backgroundImage = `url("${iconUrl}")`;
+      svgEl.style.backgroundSize = 'contain';
+      svgEl.style.backgroundRepeat = 'no-repeat';
+      svgEl.style.backgroundPosition = 'center';
+      svgEl.style.display = '';
+
+      // Mark as replaced by this extension
+      svgEl.setAttribute('data-material-icons-extension', 'icon');
+      svgEl.setAttribute('data-material-icons-extension-iconname', iconName);
+      svgEl.setAttribute('data-material-icons-extension-filename', fileName);
 
       // Get the fgColor-* class from the original svg element
       // and apply it to the link next to the icon.
@@ -110,7 +108,6 @@ export default function github(): Provider {
         const link =
           svgEl.parentElement?.nextElementSibling?.querySelector('a');
         if (link) {
-          // This will overwrite existing fgColor- classes.
           link.classList.add(fgColorClass);
         }
       }

--- a/src/providers/github.ts
+++ b/src/providers/github.ts
@@ -69,13 +69,6 @@ export default function github(): Provider {
       const fileName =
         newSVG.getAttribute('data-material-icons-extension-filename') ?? '';
 
-      // If the previous sibling is an old-style <img> icon from this extension,
-      // remove it (migration from the old approach).
-      const prevEl = svgEl.previousElementSibling;
-      if (prevEl?.getAttribute('data-material-icons-extension') === 'icon') {
-        prevEl.remove();
-      }
-
       // Clear the SVG's internal paths/shapes so nothing renders on top
       // of our background icon. This keeps the original element in the DOM
       // (avoiding GitHub SPA crashes) while visually replacing its content.

--- a/src/providers/github.ts
+++ b/src/providers/github.ts
@@ -62,6 +62,8 @@ export default function github(): Provider {
       icon.classList.contains('octicon-file-submodule'),
     getIsSymlink: ({ icon }) =>
       icon.classList.contains('octicon-file-symlink-file'),
+    getIsExpanded: ({ icon }) =>
+      icon.classList.contains('octicon-file-directory-open-fill'),
     replaceIcon: (svgEl, newSVG) => {
       const iconUrl = newSVG.getAttribute('src') ?? '';
       const iconName =
@@ -105,7 +107,30 @@ export default function github(): Provider {
         }
       }
     },
-    onAdd: () => {},
+    onAdd: (row, callback) => {
+      // GitHub's React tree view re-renders folder icons when expanding/collapsing,
+      // replacing the SVG element entirely. The selector-observer won't fire again
+      // for the same row, so we use a MutationObserver to detect these changes.
+      const observer = new MutationObserver((mutationsList) => {
+        // Only re-run if a new SVG was added (GitHub swapping the icon),
+        // not when we modify the existing SVG (setting background-image, attributes).
+        const isNewSvgAdded = mutationsList.some((mutation) =>
+          Array.from(mutation.addedNodes).some(
+            (node) =>
+              node.nodeName === 'svg' &&
+              !(node as Element).hasAttribute('data-material-icons-extension')
+          )
+        );
+
+        if (isNewSvgAdded) {
+          callback();
+        }
+      });
+      observer.observe(row, {
+        childList: true,
+        subtree: true,
+      });
+    },
     transformFileName: (
       rowEl: HTMLElement,
       _iconEl: HTMLElement,

--- a/src/providers/gitlab.test.ts
+++ b/src/providers/gitlab.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import gitlab from './gitlab';
+
+describe('GitLab provider', () => {
+  const provider = gitlab();
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    document.body.className = '';
+  });
+
+  describe('basic properties', () => {
+    it('should have name "gitlab"', () => {
+      expect(provider.name).toBe('gitlab');
+    });
+
+    it('should have domain host "gitlab.com"', () => {
+      expect(provider.domains[0].host).toBe('gitlab.com');
+    });
+
+    it('should match "gitlab.com" with the regex', () => {
+      expect(provider.domains[0].test.test('gitlab.com')).toBe(true);
+    });
+
+    it('should not match other domains with the regex', () => {
+      expect(provider.domains[0].test.test('notgitlab.com')).toBe(false);
+      expect(provider.domains[0].test.test('gitlab.com.evil.com')).toBe(false);
+    });
+  });
+
+  describe('getIsLightTheme', () => {
+    it('should return true when body does not have "gl-dark" class', () => {
+      document.body.classList.remove('gl-dark');
+      expect(provider.getIsLightTheme()).toBe(true);
+    });
+
+    it('should return false when body has "gl-dark" class', () => {
+      document.body.classList.add('gl-dark');
+      expect(provider.getIsLightTheme()).toBe(false);
+    });
+  });
+
+  describe('getIsDirectory', () => {
+    it('should return true when icon has data-testid="folder-icon"', () => {
+      document.body.innerHTML = '<svg data-testid="folder-icon"></svg>';
+      const icon = document.querySelector('svg') as unknown as HTMLElement;
+      expect(provider.getIsDirectory({ row: document.body, icon })).toBe(true);
+    });
+
+    it('should return false for file icons', () => {
+      document.body.innerHTML = '<svg data-testid="doc-code-icon"></svg>';
+      const icon = document.querySelector('svg') as unknown as HTMLElement;
+      expect(provider.getIsDirectory({ row: document.body, icon })).toBe(
+        false
+      );
+    });
+  });
+
+  describe('getIsSubmodule', () => {
+    it('should detect submodule via is-submodule class on link', () => {
+      document.body.innerHTML = `
+        <div class="tree-item">
+          <a class="is-submodule" href="#">submod</a>
+        </div>
+      `;
+      const row = document.querySelector('.tree-item') as HTMLElement;
+      const icon = document.createElement('svg') as unknown as HTMLElement;
+      expect(provider.getIsSubmodule({ row, icon })).toBe(true);
+    });
+
+    it('should return false when no submodule indicators exist', () => {
+      document.body.innerHTML = `
+        <div class="tree-item">
+          <a href="#">file.ts</a>
+        </div>
+      `;
+      const row = document.querySelector('.tree-item') as HTMLElement;
+      const icon = document.createElement('svg') as unknown as HTMLElement;
+      expect(provider.getIsSubmodule({ row, icon })).toBe(false);
+    });
+  });
+
+  describe('getIsSymlink', () => {
+    it('should return true when icon has data-testid="symlink-icon"', () => {
+      document.body.innerHTML = '<svg data-testid="symlink-icon"></svg>';
+      const icon = document.querySelector('svg') as unknown as HTMLElement;
+      expect(provider.getIsSymlink({ row: document.body, icon })).toBe(true);
+    });
+
+    it('should return false for non-symlink icons', () => {
+      document.body.innerHTML = '<svg data-testid="doc-code-icon"></svg>';
+      const icon = document.querySelector('svg') as unknown as HTMLElement;
+      expect(provider.getIsSymlink({ row: document.body, icon })).toBe(false);
+    });
+  });
+
+  describe('replaceIcon', () => {
+    it('should copy attributes from old SVG to new element', () => {
+      document.body.innerHTML =
+        '<svg class="gl-icon" viewBox="0 0 16 16"></svg>';
+      const svgEl = document.querySelector('svg') as unknown as HTMLElement;
+      const newSVG = document.createElement('svg') as unknown as HTMLElement;
+
+      provider.replaceIcon(svgEl, newSVG);
+
+      expect(newSVG.getAttribute('class')).toBe('gl-icon');
+      expect(newSVG.getAttribute('viewBox')).toBe('0 0 16 16');
+    });
+
+    it('should NOT copy "src" attribute', () => {
+      document.body.innerHTML = '<svg src="old.svg"></svg>';
+      const svgEl = document.querySelector('svg') as unknown as HTMLElement;
+      const newSVG = document.createElement('svg') as unknown as HTMLElement;
+
+      provider.replaceIcon(svgEl, newSVG);
+
+      expect(newSVG.getAttribute('src')).toBeNull();
+    });
+
+    it('should NOT copy "data-material-icons-extension-*" attributes', () => {
+      document.body.innerHTML =
+        '<svg data-material-icons-extension="icon" data-material-icons-extension-iconname="test.svg"></svg>';
+      const svgEl = document.querySelector('svg') as unknown as HTMLElement;
+      const newSVG = document.createElement('svg') as unknown as HTMLElement;
+
+      provider.replaceIcon(svgEl, newSVG);
+
+      expect(
+        newSVG.getAttribute('data-material-icons-extension')
+      ).toBeNull();
+      expect(
+        newSVG.getAttribute('data-material-icons-extension-iconname')
+      ).toBeNull();
+    });
+
+    it('should set width and height to 16px', () => {
+      document.body.innerHTML = '<svg class="gl-icon"></svg>';
+      const svgEl = document.querySelector('svg') as unknown as HTMLElement;
+      const newSVG = document.createElement('svg') as unknown as HTMLElement;
+
+      provider.replaceIcon(svgEl, newSVG);
+
+      expect(newSVG.style.height).toBe('16px');
+      expect(newSVG.style.width).toBe('16px');
+    });
+
+    it('should replace the old element in the DOM', () => {
+      document.body.innerHTML =
+        '<div class="container"><svg class="gl-icon"></svg></div>';
+      const container = document.querySelector('.container') as HTMLElement;
+      const svgEl = document.querySelector('svg') as unknown as HTMLElement;
+      const newSVG = document.createElement('svg') as unknown as HTMLElement;
+
+      provider.replaceIcon(svgEl, newSVG);
+
+      expect(container.contains(svgEl)).toBe(false);
+      expect(container.contains(newSVG)).toBe(true);
+    });
+  });
+
+  describe('transformFileName', () => {
+    it('should pass through normal filenames unchanged', () => {
+      const row = document.createElement('div');
+      const icon = document.createElement('svg') as unknown as HTMLElement;
+      expect(provider.transformFileName(row, icon, 'index.ts')).toBe(
+        'index.ts'
+      );
+    });
+
+    it('should transform "Source code (zip)" on release asset rows', () => {
+      document.body.innerHTML = `
+        <div class="js-assets-list">
+          <ul>
+            <li><span>Source code (zip)</span></li>
+          </ul>
+        </div>
+      `;
+      const li = document.querySelector('li') as HTMLElement;
+      const icon = document.createElement('svg') as unknown as HTMLElement;
+      expect(
+        provider.transformFileName(li, icon, 'Source code (zip)')
+      ).toBe('Source code.zip');
+    });
+
+    it('should transform "Source code (tar.gz)" on release asset rows', () => {
+      document.body.innerHTML = `
+        <div class="js-assets-list">
+          <ul>
+            <li><span>Source code (tar.gz)</span></li>
+          </ul>
+        </div>
+      `;
+      const li = document.querySelector('li') as HTMLElement;
+      const icon = document.createElement('svg') as unknown as HTMLElement;
+      expect(
+        provider.transformFileName(li, icon, 'Source code (tar.gz)')
+      ).toBe('Source code.tar.gz');
+    });
+  });
+});

--- a/src/providers/sourceforge.test.ts
+++ b/src/providers/sourceforge.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import sourceforge from './sourceforge';
+
+describe('SourceForge provider', () => {
+  const provider = sourceforge();
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  describe('basic properties', () => {
+    it('should have name "sourceforge"', () => {
+      expect(provider.name).toBe('sourceforge');
+    });
+
+    it('should have domain host "sourceforge.net"', () => {
+      expect(provider.domains[0].host).toBe('sourceforge.net');
+    });
+
+    it('should match "sourceforge.net" with the regex', () => {
+      expect(provider.domains[0].test.test('sourceforge.net')).toBe(true);
+    });
+
+    it('should not match other domains', () => {
+      expect(provider.domains[0].test.test('notsourceforge.net')).toBe(false);
+      expect(provider.domains[0].test.test('sourceforge.net.evil.com')).toBe(
+        false
+      );
+    });
+
+    it('should not be able to self host', () => {
+      expect(provider.canSelfHost).toBe(false);
+    });
+
+    it('should not be custom', () => {
+      expect(provider.isCustom).toBe(false);
+    });
+  });
+
+  describe('getIsLightTheme', () => {
+    it('should always return true (no dark theme available)', () => {
+      expect(provider.getIsLightTheme()).toBe(true);
+    });
+  });
+
+  describe('getIsDirectory', () => {
+    it('should return true when icon is an I element with "fa-folder" class', () => {
+      document.body.innerHTML =
+        '<tr><td><i class="fa fa-folder"></i></td></tr>';
+      const row = document.querySelector('tr') as HTMLElement;
+      const icon = document.querySelector('i') as HTMLElement;
+      expect(provider.getIsDirectory({ row, icon })).toBe(true);
+    });
+
+    it('should return false when icon is an I element without "fa-folder" class', () => {
+      document.body.innerHTML =
+        '<tr><td><i class="fa fa-file"></i></td></tr>';
+      const row = document.querySelector('tr') as HTMLElement;
+      const icon = document.querySelector('i') as HTMLElement;
+      expect(provider.getIsDirectory({ row, icon })).toBe(false);
+    });
+
+    it('should return true when icon is not an I element and row has "folder" class', () => {
+      document.body.innerHTML =
+        '<table><tbody><tr class="folder"><th><a href="#">Folder</a></th></tr></tbody></table>';
+      const row = document.querySelector('tr') as HTMLElement;
+      const icon = document.querySelector('a') as HTMLElement;
+      expect(provider.getIsDirectory({ row, icon })).toBe(true);
+    });
+
+    it('should return false when icon is not an I element and row does not have "folder" class', () => {
+      document.body.innerHTML =
+        '<table><tbody><tr class="file"><th><a href="#">File.txt</a></th></tr></tbody></table>';
+      const row = document.querySelector('tr') as HTMLElement;
+      const icon = document.querySelector('a') as HTMLElement;
+      expect(provider.getIsDirectory({ row, icon })).toBe(false);
+    });
+  });
+
+  describe('getIsSubmodule', () => {
+    it('should always return false', () => {
+      const row = document.createElement('tr');
+      const icon = document.createElement('i');
+      expect(provider.getIsSubmodule({ row, icon })).toBe(false);
+    });
+  });
+
+  describe('getIsSymlink', () => {
+    it('should return true when icon is an I element with "fa-star" class', () => {
+      document.body.innerHTML = '<tr><td><i class="fa fa-star"></i></td></tr>';
+      const row = document.querySelector('tr') as HTMLElement;
+      const icon = document.querySelector('i') as HTMLElement;
+      expect(provider.getIsSymlink({ row, icon })).toBe(true);
+    });
+
+    it('should return false when icon is an I element without "fa-star" class', () => {
+      document.body.innerHTML = '<tr><td><i class="fa fa-file"></i></td></tr>';
+      const row = document.querySelector('tr') as HTMLElement;
+      const icon = document.querySelector('i') as HTMLElement;
+      expect(provider.getIsSymlink({ row, icon })).toBe(false);
+    });
+
+    it('should return false when icon is not an I element', () => {
+      document.body.innerHTML =
+        '<tr><th><a href="#" class="fa-star">Link</a></th></tr>';
+      const row = document.querySelector('tr') as HTMLElement;
+      const icon = document.querySelector('a') as HTMLElement;
+      expect(provider.getIsSymlink({ row, icon })).toBe(false);
+    });
+  });
+
+  describe('replaceIcon', () => {
+    describe('when icon is an I element', () => {
+      it('should set verticalAlign to text-bottom', () => {
+        document.body.innerHTML =
+          '<div><a class="icon"><i class="fa fa-file"></i></a></div>';
+        const icon = document.querySelector('i') as HTMLElement;
+        const newSVG = document.createElement('img') as unknown as HTMLElement;
+
+        provider.replaceIcon(icon, newSVG);
+
+        expect(newSVG.style.verticalAlign).toBe('text-bottom');
+      });
+
+      it('should set height to 14px and width to 14px', () => {
+        document.body.innerHTML =
+          '<div><a class="icon"><i class="fa fa-file"></i></a></div>';
+        const icon = document.querySelector('i') as HTMLElement;
+        const newSVG = document.createElement('img') as unknown as HTMLElement;
+
+        provider.replaceIcon(icon, newSVG);
+
+        expect(newSVG.style.height).toBe('14px');
+        expect(newSVG.style.width).toBe('14px');
+      });
+
+      it('should replace the I element in the DOM', () => {
+        document.body.innerHTML =
+          '<div><a class="icon"><i class="fa fa-file"></i></a></div>';
+        const anchor = document.querySelector('a') as HTMLElement;
+        const icon = document.querySelector('i') as HTMLElement;
+        const newSVG = document.createElement('img') as unknown as HTMLElement;
+
+        provider.replaceIcon(icon, newSVG);
+
+        expect(anchor.contains(icon)).toBe(false);
+        expect(anchor.contains(newSVG)).toBe(true);
+      });
+    });
+
+    describe('when icon is an A (anchor) element', () => {
+      it('should set verticalAlign to text-bottom', () => {
+        document.body.innerHTML =
+          '<th><a href="#"><svg><path d="M1"></path></svg> File.txt</a></th>';
+        const anchor = document.querySelector('a') as HTMLElement;
+        const newSVG = document.createElement('img') as unknown as HTMLElement;
+
+        provider.replaceIcon(anchor, newSVG);
+
+        expect(newSVG.style.verticalAlign).toBe('text-bottom');
+      });
+
+      it('should set height to 20px and width to 20px', () => {
+        document.body.innerHTML =
+          '<th><a href="#"><svg><path d="M1"></path></svg> File.txt</a></th>';
+        const anchor = document.querySelector('a') as HTMLElement;
+        const newSVG = document.createElement('img') as unknown as HTMLElement;
+
+        provider.replaceIcon(anchor, newSVG);
+
+        expect(newSVG.style.height).toBe('20px');
+        expect(newSVG.style.width).toBe('20px');
+      });
+
+      it('should replace the SVG inside the anchor element', () => {
+        document.body.innerHTML =
+          '<th><a href="#"><svg><path d="M1"></path></svg> File.txt</a></th>';
+        const anchor = document.querySelector('a') as HTMLElement;
+        const svgInside = document.querySelector('svg') as Element;
+        const newSVG = document.createElement('img') as unknown as HTMLElement;
+
+        provider.replaceIcon(anchor, newSVG);
+
+        expect(anchor.contains(svgInside)).toBe(false);
+        expect(anchor.contains(newSVG)).toBe(true);
+      });
+
+      it('should prepend the new icon if no SVG exists inside anchor', () => {
+        document.body.innerHTML =
+          '<th><a href="#">File.txt</a></th>';
+        const anchor = document.querySelector('a') as HTMLElement;
+        const newSVG = document.createElement('img') as unknown as HTMLElement;
+
+        provider.replaceIcon(anchor, newSVG);
+
+        expect(anchor.firstChild).toBe(newSVG);
+      });
+
+      it('should not replace/prepend if already has material-icons-extension icon', () => {
+        document.body.innerHTML =
+          '<th><a href="#"><img data-material-icons-extension="icon" /> File.txt</a></th>';
+        const anchor = document.querySelector('a') as HTMLElement;
+        const newSVG = document.createElement('img') as unknown as HTMLElement;
+
+        provider.replaceIcon(anchor, newSVG);
+
+        // Should still only have the one img
+        expect(anchor.querySelectorAll('img').length).toBe(1);
+        // The new SVG should NOT be in the DOM
+        expect(anchor.contains(newSVG)).toBe(false);
+      });
+    });
+  });
+
+  describe('onAdd', () => {
+    it('should be a no-op function', () => {
+      const row = document.createElement('tr');
+      const callback = () => {};
+      expect(() => provider.onAdd(row, callback)).not.toThrow();
+    });
+  });
+
+  describe('transformFileName', () => {
+    it('should pass through filename unchanged', () => {
+      const row = document.createElement('tr');
+      const icon = document.createElement('i');
+      expect(provider.transformFileName(row, icon, 'readme.txt')).toBe(
+        'readme.txt'
+      );
+    });
+  });
+});

--- a/src/providers/tangled.test.ts
+++ b/src/providers/tangled.test.ts
@@ -1,0 +1,289 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import tangled from './tangled';
+
+describe('Tangled provider', () => {
+  const provider = tangled();
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    document.documentElement.className = '';
+  });
+
+  describe('basic properties', () => {
+    it('should have name "tangled"', () => {
+      expect(provider.name).toBe('tangled');
+    });
+
+    it('should have domain host "tangled.org"', () => {
+      expect(provider.domains[0].host).toBe('tangled.org');
+    });
+
+    it('should match "tangled.org" with the regex', () => {
+      expect(provider.domains[0].test.test('tangled.org')).toBe(true);
+    });
+
+    it('should not match other domains', () => {
+      expect(provider.domains[0].test.test('nottangled.org')).toBe(false);
+      expect(provider.domains[0].test.test('tangled.org.evil.com')).toBe(
+        false
+      );
+    });
+
+    it('should not be able to self host', () => {
+      expect(provider.canSelfHost).toBe(false);
+    });
+
+    it('should not be custom', () => {
+      expect(provider.isCustom).toBe(false);
+    });
+  });
+
+  describe('getIsLightTheme', () => {
+    it('should return false when html has "dark" class', () => {
+      document.documentElement.classList.add('dark');
+      expect(provider.getIsLightTheme()).toBe(false);
+    });
+
+    it('should return true when html does not have "dark" class and prefers-color-scheme is light', () => {
+      document.documentElement.classList.remove('dark');
+      // jsdom defaults to no dark preference
+      Object.defineProperty(window, 'matchMedia', {
+        value: (query: string) => ({
+          matches: query === '(prefers-color-scheme: dark)' ? false : false,
+          media: query,
+          onchange: null,
+          addListener: () => {},
+          removeListener: () => {},
+          addEventListener: () => {},
+          removeEventListener: () => {},
+          dispatchEvent: () => false,
+        }),
+        configurable: true,
+      });
+
+      expect(provider.getIsLightTheme()).toBe(true);
+    });
+
+    it('should return false when html does not have "dark" class but prefers-color-scheme is dark', () => {
+      document.documentElement.classList.remove('dark');
+      Object.defineProperty(window, 'matchMedia', {
+        value: (query: string) => ({
+          matches: query === '(prefers-color-scheme: dark)' ? true : false,
+          media: query,
+          onchange: null,
+          addListener: () => {},
+          removeListener: () => {},
+          addEventListener: () => {},
+          removeEventListener: () => {},
+          dispatchEvent: () => false,
+        }),
+        configurable: true,
+      });
+
+      expect(provider.getIsLightTheme()).toBe(false);
+    });
+  });
+
+  describe('getIsDirectory', () => {
+    it('should return true when icon has "fill-current" class', () => {
+      document.body.innerHTML =
+        '<div class="grid"><svg class="fill-current"></svg></div>';
+      const row = document.querySelector('.grid') as HTMLElement;
+      const icon = document.querySelector('svg') as unknown as HTMLElement;
+      expect(provider.getIsDirectory({ row, icon })).toBe(true);
+    });
+
+    it('should return true when row has "tree-directory" class', () => {
+      document.body.innerHTML =
+        '<div class="tree-directory"><svg></svg></div>';
+      const row = document.querySelector('.tree-directory') as HTMLElement;
+      const icon = document.querySelector('svg') as unknown as HTMLElement;
+      expect(provider.getIsDirectory({ row, icon })).toBe(true);
+    });
+
+    it('should return true when icon contains folder SVG path', () => {
+      document.body.innerHTML = `
+        <div class="grid">
+          <svg><path d="M20 20a2 something"></path></svg>
+        </div>
+      `;
+      const row = document.querySelector('.grid') as HTMLElement;
+      const icon = document.querySelector('svg') as unknown as HTMLElement;
+      expect(provider.getIsDirectory({ row, icon })).toBe(true);
+    });
+
+    it('should return false for file icons', () => {
+      document.body.innerHTML =
+        '<div class="grid"><svg class="text-muted"><path d="M5 3"></path></svg></div>';
+      const row = document.querySelector('.grid') as HTMLElement;
+      const icon = document.querySelector('svg') as unknown as HTMLElement;
+      expect(provider.getIsDirectory({ row, icon })).toBe(false);
+    });
+  });
+
+  describe('getIsSubmodule', () => {
+    it('should always return false', () => {
+      const row = document.createElement('div');
+      const icon = document.createElement('svg') as unknown as HTMLElement;
+      expect(provider.getIsSubmodule({ row, icon })).toBe(false);
+    });
+  });
+
+  describe('getIsSymlink', () => {
+    it('should always return false', () => {
+      const row = document.createElement('div');
+      const icon = document.createElement('svg') as unknown as HTMLElement;
+      expect(provider.getIsSymlink({ row, icon })).toBe(false);
+    });
+  });
+
+  describe('replaceIcon', () => {
+    it('should copy attributes from old SVG to new element', () => {
+      document.body.innerHTML =
+        '<div><svg class="w-4 h-4 text-muted" viewBox="0 0 16 16"></svg></div>';
+      const svgEl = document.querySelector('svg') as unknown as HTMLElement;
+      const newSVG = document.createElement('svg') as unknown as HTMLElement;
+
+      provider.replaceIcon(svgEl, newSVG);
+
+      expect(newSVG.getAttribute('viewBox')).toBe('0 0 16 16');
+    });
+
+    it('should NOT copy "src" attribute', () => {
+      document.body.innerHTML = '<div><svg src="old.svg"></svg></div>';
+      const svgEl = document.querySelector('svg') as unknown as HTMLElement;
+      const newSVG = document.createElement('svg') as unknown as HTMLElement;
+
+      provider.replaceIcon(svgEl, newSVG);
+
+      expect(newSVG.getAttribute('src')).toBeNull();
+    });
+
+    it('should NOT copy "data-material-icons-extension-*" attributes', () => {
+      document.body.innerHTML =
+        '<div><svg data-material-icons-extension="icon" data-material-icons-extension-iconname="test.svg"></svg></div>';
+      const svgEl = document.querySelector('svg') as unknown as HTMLElement;
+      const newSVG = document.createElement('svg') as unknown as HTMLElement;
+
+      provider.replaceIcon(svgEl, newSVG);
+
+      expect(
+        newSVG.getAttribute('data-material-icons-extension')
+      ).toBeNull();
+      expect(
+        newSVG.getAttribute('data-material-icons-extension-iconname')
+      ).toBeNull();
+    });
+
+    it('should strip "group-open/" prefixed classes from newSVG', () => {
+      document.body.innerHTML =
+        '<div><svg class="w-4 h-4 group-open/folder:hidden"></svg></div>';
+      const svgEl = document.querySelector('svg') as unknown as HTMLElement;
+      const newSVG = document.createElement('svg') as unknown as HTMLElement;
+
+      provider.replaceIcon(svgEl, newSVG);
+
+      expect(newSVG.className).not.toContain('group-open/');
+    });
+
+    it('should strip "hidden" class from newSVG', () => {
+      document.body.innerHTML =
+        '<div><svg class="w-4 h-4 hidden"></svg></div>';
+      const svgEl = document.querySelector('svg') as unknown as HTMLElement;
+      const newSVG = document.createElement('svg') as unknown as HTMLElement;
+
+      provider.replaceIcon(svgEl, newSVG);
+
+      expect(newSVG.className).not.toContain('hidden');
+      expect(newSVG.className).toContain('w-4');
+      expect(newSVG.className).toContain('h-4');
+    });
+
+    it('should hide the sibling SVG if present', () => {
+      document.body.innerHTML = `
+        <div>
+          <svg class="w-4 h-4 group-open/folder:hidden"></svg>
+          <svg class="w-4 h-4 group-open/folder:block"></svg>
+        </div>
+      `;
+      const svgEl = document.querySelectorAll(
+        'svg'
+      )[0] as unknown as HTMLElement;
+      const sibling = document.querySelectorAll(
+        'svg'
+      )[1] as unknown as HTMLElement;
+      const newSVG = document.createElement('svg') as unknown as HTMLElement;
+
+      provider.replaceIcon(svgEl, newSVG);
+
+      expect(sibling.style.display).toBe('none');
+    });
+
+    it('should NOT hide the sibling if it has data-material-icons-extension attribute', () => {
+      document.body.innerHTML = `
+        <div>
+          <svg class="w-4 h-4"></svg>
+          <svg class="w-4 h-4" data-material-icons-extension="icon"></svg>
+        </div>
+      `;
+      const svgEl = document.querySelectorAll(
+        'svg'
+      )[0] as unknown as HTMLElement;
+      const sibling = document.querySelectorAll(
+        'svg'
+      )[1] as unknown as HTMLElement;
+      const newSVG = document.createElement('svg') as unknown as HTMLElement;
+
+      provider.replaceIcon(svgEl, newSVG);
+
+      expect(sibling.style.display).not.toBe('none');
+    });
+
+    it('should NOT hide the sibling if it is not an SVG', () => {
+      document.body.innerHTML = `
+        <div>
+          <svg class="w-4 h-4"></svg>
+          <span class="label">filename</span>
+        </div>
+      `;
+      const svgEl = document.querySelector('svg') as unknown as HTMLElement;
+      const span = document.querySelector('span') as HTMLElement;
+      const newSVG = document.createElement('svg') as unknown as HTMLElement;
+
+      provider.replaceIcon(svgEl, newSVG);
+
+      expect(span.style.display).not.toBe('none');
+    });
+
+    it('should replace the old element in the DOM via parentNode.replaceChild', () => {
+      document.body.innerHTML =
+        '<div class="container"><svg class="w-4 h-4"></svg></div>';
+      const container = document.querySelector('.container') as HTMLElement;
+      const svgEl = document.querySelector('svg') as unknown as HTMLElement;
+      const newSVG = document.createElement('svg') as unknown as HTMLElement;
+
+      provider.replaceIcon(svgEl, newSVG);
+
+      expect(container.contains(svgEl)).toBe(false);
+      expect(container.contains(newSVG)).toBe(true);
+    });
+  });
+
+  describe('onAdd', () => {
+    it('should be a no-op function', () => {
+      const row = document.createElement('div');
+      const callback = () => {};
+      expect(() => provider.onAdd(row, callback)).not.toThrow();
+    });
+  });
+
+  describe('transformFileName', () => {
+    it('should pass through filename unchanged', () => {
+      const row = document.createElement('div');
+      const icon = document.createElement('svg') as unknown as HTMLElement;
+      expect(provider.transformFileName(row, icon, 'index.ts')).toBe(
+        'index.ts'
+      );
+    });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+    },
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,14 @@
 import { defineConfig } from 'vitest/config';
 import path from 'path';
+import fs from 'fs';
+
+// icon-list.json is generated at build time and gitignored.
+// Create an empty stub if it doesn't exist so Vite can resolve the import
+// (tests mock this module via vi.mock).
+const iconListPath = path.resolve(__dirname, 'src/icon-list.json');
+if (!fs.existsSync(iconListPath)) {
+  fs.writeFileSync(iconListPath, '{}');
+}
 
 export default defineConfig({
   test: {


### PR DESCRIPTION
## Summary

Refactors the GitHub icon replacement to use a background-image approach (as suggested in #148), adds expanded folder icon support, and introduces a full unit test suite.

Fixes #150

## Changes

### GitHub icon replacement (background-image approach)

Instead of creating a new `<img>` element and inserting it before the hidden original SVG, we now reuse the existing `<svg>` element:

- Clear inner `<path>` elements
- Set `background-image` to the material icon SVG
- Mark the element with `data-material-icons-extension` attributes directly

This eliminates conflicts with Refined GitHub and other extensions, avoids GitHub SPA crashes (element stays in DOM), and removes the need to copy classes between elements.

Relates to: #148, #142

### Expanded folder icons

- Added optional `getIsExpanded` to the Provider interface
- GitHub provider detects `octicon-file-directory-open-fill` class
- Icon resolution now uses `manifest.folderNamesExpanded` for open folders (e.g., `folder-src-open.svg`)

### MutationObserver for folder toggle

GitHub's React tree view replaces SVG elements when expanding/collapsing folders. Added a `MutationObserver` in `onAdd` to detect new unprocessed SVGs and re-run icon replacement.

### Unit test suite (245 tests)

- Set up Vitest with jsdom
- Tests for all providers: github, gitlab, bitbucket, gitea, forgejo, azure, gitee, tangled, sourceforge
- Tests for core logic: icon resolution, replaceAllIcons, user-config, icon-sizes, custom-providers
- Added `npm test` to CI workflow