### PR TITLE
feat: add support for gitlab search files tree and find files 

### DIFF
--- a/src/providers/gitlab.test.ts
+++ b/src/providers/gitlab.test.ts
@@ -1,5 +1,8 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import gitlab from './gitlab';
+
+// left-to-right mark GitLab wraps truncation spans in, kept explicit instead of embedded raw
+const LRM = '\u200E';
 
 describe('GitLab provider', () => {
   const provider = gitlab();
@@ -40,6 +43,142 @@ describe('GitLab provider', () => {
     });
   });
 
+  describe('File Tree Browser markup', () => {
+    it('should match a folder row via the row/filename/icon selectors', () => {
+      document.body.innerHTML = `
+        <a data-testid="file-row" aria-label=".github" class="file-row folder" href="/x/-/tree/main/.github">
+          <span data-testid="file-row-name-container" data-qa-file-name=".github" class="file-row-name">
+            <span class="gl-mr-2 gl-text-subtle">
+              <svg data-testid="folder-icon" role="img" aria-hidden="true" class="folder-icon">
+                <use href="#folder"></use>
+              </svg>
+            </span>
+            <span class="gl-truncate-component">
+              <span class="gl-truncate-end">.gi</span><span class="gl-truncate-start">${LRM}thub${LRM}</span>
+            </span>
+          </span>
+        </a>
+      `;
+
+      const row = document.querySelector(provider.selectors.row);
+      expect(row).not.toBeNull();
+
+      const filenameEl = row?.querySelector(provider.selectors.filename);
+      expect(filenameEl).not.toBeNull();
+      expect(filenameEl?.getAttribute('data-qa-file-name')).toBe('.github');
+
+      const iconEl = row?.querySelector(provider.selectors.icon) as HTMLElement;
+      expect(iconEl).not.toBeNull();
+      expect(
+        provider.getIsDirectory({ row: row as HTMLElement, icon: iconEl })
+      ).toBe(true);
+    });
+
+    it('should not pick up the toggle-button chevron icon for a folder row inside the tree container', () => {
+      document.body.innerHTML = `
+        <li role="treeitem" aria-label=".github">
+          <div data-testid="file-row-container">
+            <button data-testid="tree-toggle-button" type="button">
+              <svg data-testid="chevron-right-icon"><use href="#chevron-right"></use></svg>
+            </button>
+            <a href="/x/-/tree/main/.github" data-testid="file-row" aria-label=".github" class="file-row folder">
+              <span title=".github" data-qa-file-name=".github" data-testid="file-row-name-container" class="file-row-name">
+                <span class="gl-mr-2 gl-text-subtle">
+                  <svg data-testid="folder-icon" class="folder-icon"><use href="#folder"></use></svg>
+                </span>
+                <span class="gl-truncate-component"><span class="gl-truncate-end">.gi</span><span class="gl-truncate-start">${LRM}thub${LRM}</span></span>
+              </span>
+            </a>
+          </div>
+        </li>
+      `;
+
+      const row = document.querySelector(provider.selectors.row) as HTMLElement;
+      expect(row.getAttribute('data-testid')).toBe('file-row');
+
+      const iconEl = row.querySelector(provider.selectors.icon);
+      expect(iconEl?.getAttribute('data-testid')).toBe('folder-icon');
+    });
+
+    it('should resolve a plain file row whose icon has no data-testid', () => {
+      document.body.innerHTML = `
+        <a href="/x/-/blob/main/.gitignore" data-testid="file-row" aria-label=".gitignore" class="file-row">
+          <span title=".gitignore" data-qa-file-name=".gitignore" data-testid="file-row-name-container" class="file-row-name">
+            <span class="gl-mr-2">
+              <svg class="s16"><use href="#git"></use></svg>
+            </span>
+            <span class="gl-truncate-component"><span class="gl-truncate-end">.giti</span><span class="gl-truncate-start">${LRM}gnore${LRM}</span></span>
+          </span>
+        </a>
+      `;
+
+      const row = document.querySelector(provider.selectors.row) as HTMLElement;
+      const filenameEl = row.querySelector(provider.selectors.filename);
+      expect(filenameEl?.getAttribute('data-qa-file-name')).toBe('.gitignore');
+
+      const iconEl = row.querySelector(provider.selectors.icon) as HTMLElement;
+      expect(iconEl).not.toBeNull();
+      expect(provider.getIsDirectory({ row, icon: iconEl })).toBe(false);
+    });
+  });
+
+  describe('"Find file" search dropdown markup', () => {
+    it('should match a plain file result via the row/filename/icon selectors', () => {
+      document.body.innerHTML = `
+        <li tabindex="0" data-testid="disclosure-dropdown-item" class="gl-new-dropdown-item">
+          <a href="/x/-/blob/dev/index.ts" tabindex="-1" data-track-action="click_command_palette_item" data-track-label="file" class="gl-new-dropdown-item-content">
+            <span class="gl-new-dropdown-item-text-wrapper">
+              <div class="gl-flex gl-items-center">
+                <svg data-testid="icon" role="img" aria-hidden="true" class="gl-mr-3 gl-shrink-0 gl-icon s16 gl-fill-current">
+                  <use href="#doc-code"></use>
+                </svg>
+                <span class="gl-flex gl-min-w-0 gl-items-center gl-gap-2">
+                  <span class="gl-truncate">
+                    <span data-testid="unhighlighted-segment">index.ts</span>
+                  </span>
+                </span>
+              </div>
+            </span>
+          </a>
+        </li>
+      `;
+
+      const row = document.querySelector(provider.selectors.row) as HTMLElement;
+      expect(row.getAttribute('data-track-label')).toBe('file');
+
+      const filenameEl = row.querySelector(provider.selectors.filename);
+      expect(filenameEl?.textContent?.trim()).toBe('index.ts');
+
+      const iconEl = row.querySelector(provider.selectors.icon) as HTMLElement;
+      expect(iconEl?.getAttribute('data-testid')).toBe('icon');
+      expect(provider.getIsDirectory({ row, icon: iconEl })).toBe(false);
+    });
+
+    it('should expose the full nested path for a result under a subdirectory, letting the generic last-segment split resolve the base filename', () => {
+      document.body.innerHTML = `
+        <li tabindex="0" data-testid="disclosure-dropdown-item" class="gl-new-dropdown-item">
+          <a href="/x/-/blob/dev/src/lib/index.ts" tabindex="-1" data-track-action="click_command_palette_item" data-track-label="file" class="gl-new-dropdown-item-content">
+            <span class="gl-new-dropdown-item-text-wrapper">
+              <div class="gl-flex gl-items-center">
+                <svg data-testid="icon"><use href="#doc-code"></use></svg>
+                <span class="gl-flex gl-min-w-0 gl-items-center gl-gap-2">
+                  <span class="gl-truncate">
+                    <span data-testid="unhighlighted-segment">src/lib/index.ts</span>
+                  </span>
+                </span>
+              </div>
+            </span>
+          </a>
+        </li>
+      `;
+
+      const row = document.querySelector(provider.selectors.row) as HTMLElement;
+      const filenameEl = row.querySelector(provider.selectors.filename);
+      // no truncation-span splitting on this markup, so raw textContent is already clean
+      expect(filenameEl?.textContent?.trim()).toBe('src/lib/index.ts');
+    });
+  });
+
   describe('getIsDirectory', () => {
     it('should return true when icon has data-testid="folder-icon"', () => {
       document.body.innerHTML = '<svg data-testid="folder-icon"></svg>';
@@ -50,9 +189,7 @@ describe('GitLab provider', () => {
     it('should return false for file icons', () => {
       document.body.innerHTML = '<svg data-testid="doc-code-icon"></svg>';
       const icon = document.querySelector('svg') as unknown as HTMLElement;
-      expect(provider.getIsDirectory({ row: document.body, icon })).toBe(
-        false
-      );
+      expect(provider.getIsDirectory({ row: document.body, icon })).toBe(false);
     });
   });
 
@@ -125,9 +262,7 @@ describe('GitLab provider', () => {
 
       provider.replaceIcon(svgEl, newSVG);
 
-      expect(
-        newSVG.getAttribute('data-material-icons-extension')
-      ).toBeNull();
+      expect(newSVG.getAttribute('data-material-icons-extension')).toBeNull();
       expect(
         newSVG.getAttribute('data-material-icons-extension-iconname')
       ).toBeNull();
@@ -167,6 +302,25 @@ describe('GitLab provider', () => {
       );
     });
 
+    it('should use the clean data-qa-file-name attribute for File Tree Browser rows, ignoring the truncated textContent-derived name', () => {
+      document.body.innerHTML = `
+        <a data-testid="file-row" aria-label=".github" class="file-row folder">
+          <span data-testid="file-row-name-container" data-qa-file-name=".github" class="file-row-name">
+            <span class="gl-truncate-component"><span class="gl-truncate-end">.gi</span><span class="gl-truncate-start">${LRM}thub${LRM}</span></span>
+          </span>
+        </a>
+      `;
+      const row = document.querySelector(
+        '[data-testid="file-row"]'
+      ) as HTMLElement;
+      const icon = document.createElement('svg') as unknown as HTMLElement;
+
+      // simulates the garbled name replace-icon.ts would have extracted via textContent
+      expect(provider.transformFileName(row, icon, `.gi${LRM}thub${LRM}`)).toBe(
+        '.github'
+      );
+    });
+
     it('should transform "Source code (zip)" on release asset rows', () => {
       document.body.innerHTML = `
         <div class="js-assets-list">
@@ -177,9 +331,9 @@ describe('GitLab provider', () => {
       `;
       const li = document.querySelector('li') as HTMLElement;
       const icon = document.createElement('svg') as unknown as HTMLElement;
-      expect(
-        provider.transformFileName(li, icon, 'Source code (zip)')
-      ).toBe('Source code.zip');
+      expect(provider.transformFileName(li, icon, 'Source code (zip)')).toBe(
+        'Source code.zip'
+      );
     });
 
     it('should transform "Source code (tar.gz)" on release asset rows', () => {
@@ -192,9 +346,9 @@ describe('GitLab provider', () => {
       `;
       const li = document.querySelector('li') as HTMLElement;
       const icon = document.createElement('svg') as unknown as HTMLElement;
-      expect(
-        provider.transformFileName(li, icon, 'Source code (tar.gz)')
-      ).toBe('Source code.tar.gz');
+      expect(provider.transformFileName(li, icon, 'Source code (tar.gz)')).toBe(
+        'Source code.tar.gz'
+      );
     });
   });
 });

--- a/src/providers/gitlab.test.ts
+++ b/src/providers/gitlab.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import gitlab from './gitlab';
 
 // left-to-right mark GitLab wraps truncation spans in, kept explicit instead of embedded raw

--- a/src/providers/gitlab.test.ts
+++ b/src/providers/gitlab.test.ts
@@ -189,7 +189,9 @@ describe('GitLab provider', () => {
     it('should return false for file icons', () => {
       document.body.innerHTML = '<svg data-testid="doc-code-icon"></svg>';
       const icon = document.querySelector('svg') as unknown as HTMLElement;
-      expect(provider.getIsDirectory({ row: document.body, icon })).toBe(false);
+      expect(provider.getIsDirectory({ row: document.body, icon })).toBe(
+        false
+      );
     });
   });
 
@@ -262,7 +264,9 @@ describe('GitLab provider', () => {
 
       provider.replaceIcon(svgEl, newSVG);
 
-      expect(newSVG.getAttribute('data-material-icons-extension')).toBeNull();
+      expect(
+        newSVG.getAttribute('data-material-icons-extension')
+      ).toBeNull();
       expect(
         newSVG.getAttribute('data-material-icons-extension-iconname')
       ).toBeNull();
@@ -331,9 +335,9 @@ describe('GitLab provider', () => {
       `;
       const li = document.querySelector('li') as HTMLElement;
       const icon = document.createElement('svg') as unknown as HTMLElement;
-      expect(provider.transformFileName(li, icon, 'Source code (zip)')).toBe(
-        'Source code.zip'
-      );
+      expect(
+        provider.transformFileName(li, icon, 'Source code (zip)')
+      ).toBe('Source code.zip');
     });
 
     it('should transform "Source code (tar.gz)" on release asset rows', () => {
@@ -346,9 +350,9 @@ describe('GitLab provider', () => {
       `;
       const li = document.querySelector('li') as HTMLElement;
       const icon = document.createElement('svg') as unknown as HTMLElement;
-      expect(provider.transformFileName(li, icon, 'Source code (tar.gz)')).toBe(
-        'Source code.tar.gz'
-      );
+      expect(
+        provider.transformFileName(li, icon, 'Source code (tar.gz)')
+      ).toBe('Source code.tar.gz');
     });
   });
 });

--- a/src/providers/gitlab.ts
+++ b/src/providers/gitlab.ts
@@ -13,17 +13,23 @@ export default function gitlab(): Provider {
       // Row in file list, file view header
       row: `table[data-testid="file-tree-table"].table.tree-table tr.tree-item,
          table[data-qa-selector="file_tree_table"] tr,
+         a[data-testid="file-row"],
+         a[data-track-label="file"],
          .file-header-content,
          .gl-card[data-testid="release-block"] .js-assets-list ul li`,
       // Cell in file list, file view header, readme header
       filename: `.tree-item-file-name .tree-item-link,
         .tree-item-file-name,
+        span[data-testid="file-row-name-container"],
+        a[data-track-label="file"] span.gl-truncate,
         .file-header-content .file-title-name,
         .file-header-content .gl-link,
         .gl-link`,
       // Any icon not contained in a button
       icon: `.tree-item-file-name .tree-item-link svg,
         .tree-item svg, .file-header-content svg:not(.gl-button-icon),
+        a[data-testid="file-row"] svg,
+        a[data-track-label="file"] svg,
         .gl-link svg.gl-icon[data-testid="doc-code-icon"]`,
       // Element by which to detect if the tested domain is gitlab.
       detect: 'head meta[content="GitLab"]',
@@ -59,6 +65,12 @@ export default function gitlab(): Provider {
       _iconEl: HTMLElement,
       fileName: string
     ): string => {
+      // file tree browser rows split the name across truncation spans, so read the clean name off the attribute instead
+      const fileRowName = rowEl
+        .querySelector('span[data-testid="file-row-name-container"]')
+        ?.getAttribute('data-qa-file-name');
+      if (fileRowName) return fileRowName;
+
       // try to match the 'Source code (zip)' type of rows in releases page in github.
       if (
         rowEl.parentElement?.parentElement?.classList.contains(


### PR DESCRIPTION
## Summary

Adds support for two GitLab UI elements that weren't previously getting Material icons: the **search files tree** panel and the **find files** modal.

Fixes #152

## Changes

Added 2 new selectors for GitLab:

### 1. Search Files Tree

The file tree shown on the left side of the search-files view (used to browse/search files within the currently opened repository) now gets file-type icons instead of GitLab's default icons.

| Before                                                                                                                                       | After                                                                                                                                        |
| -------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
| <img width="488" alt="Search files tree - before 1" src="https://github.com/user-attachments/assets/76d8cf4a-9744-4213-9868-7372fd9f01fd" /> | <img width="480" alt="Search files tree - before 2" src="https://github.com/user-attachments/assets/f9b9fca7-95ec-4528-a3de-3dc77613dd06" /> |

### 2. Find Files

The "Find Files" modal — opened via the **Find Files** button next to the **Code** button, with the `~` placeholder — now shows file-type icons in its file list.

| Before                                                                                                                              | After                                                                                                                              |
| ----------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
| <img width="571" alt="Find files - before" src="https://github.com/user-attachments/assets/23010ffa-e41c-49ba-b210-7dc20aeaea9d" /> | <img width="579" alt="Find files - after" src="https://github.com/user-attachments/assets/ec5332dc-87c7-44f7-b495-b328afd7f8d2" /> |

## Testing

- Verified icons render correctly on both the search files tree and the find files modal on a live GitLab repository.
- Confirmed no regressions on the existing GitLab file tree / file view selectors.

## Notes

- One commit reverts an unrelated import-sorting change and another reverts unrelated changes, so the diff should now be scoped to just the selector additions.
