### PR TITLE
feat: add cnb.cool provider

### DIFF
--- a/src/manifests/base.json
+++ b/src/manifests/base.json
@@ -19,16 +19,13 @@
         "*://gitea.com/*",
         "*://gitlab.com/*",
         "*://gitee.com/*",
+        "*://cnb.cool/*",
         "*://sourceforge.net/*",
         "*://codeberg.org/*",
         "*://tangled.org/*"
       ],
-      "js": [
-        "./main.js"
-      ],
-      "css": [
-        "./injected-styles.css"
-      ],
+      "js": ["./main.js"],
+      "css": ["./injected-styles.css"],
       "run_at": "document_start"
     }
   ],
@@ -36,17 +33,11 @@
     "page": "options.html",
     "open_in_tab": true
   },
-  "permissions": [
-    "storage",
-    "activeTab",
-    "scripting"
-  ],
+  "permissions": ["storage", "activeTab", "scripting"],
   "manifest_version": 3,
   "web_accessible_resources": [
     {
-      "resources": [
-        "*.svg"
-      ],
+      "resources": ["*.svg"],
       "matches": [
         "*://github.com/*",
         "*://bitbucket.org/*",
@@ -55,6 +46,7 @@
         "*://gitea.com/*",
         "*://gitlab.com/*",
         "*://gitee.com/*",
+        "*://cnb.cool/*",
         "*://sourceforge.net/*",
         "*://codeberg.org/*",
         "*://tangled.org/*",

--- a/src/providers/cnb.test.ts
+++ b/src/providers/cnb.test.ts
@@ -1,0 +1,251 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import cnb from './cnb';
+
+describe('CNB provider', () => {
+  const provider = cnb();
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    document.documentElement.classList.remove('dark');
+  });
+
+  describe('basic properties', () => {
+    it('should have name "cnb"', () => {
+      expect(provider.name).toBe('cnb');
+    });
+
+    it('should have domain host "cnb.cool"', () => {
+      expect(provider.domains[0].host).toBe('cnb.cool');
+    });
+
+    it('should match "cnb.cool" with the regex', () => {
+      expect(provider.domains[0].test.test('cnb.cool')).toBe(true);
+    });
+
+    it('should not match other domains', () => {
+      expect(provider.domains[0].test.test('notcnb.cool')).toBe(false);
+      expect(provider.domains[0].test.test('cnb.cool.evil.com')).toBe(false);
+    });
+
+    it('should not be able to self host', () => {
+      expect(provider.canSelfHost).toBe(false);
+    });
+
+    it('should not be custom', () => {
+      expect(provider.isCustom).toBe(false);
+    });
+  });
+
+  describe('getIsLightTheme', () => {
+    it('should return true when <html> has no "dark" class', () => {
+      document.documentElement.classList.remove('dark');
+      expect(provider.getIsLightTheme()).toBe(true);
+    });
+
+    it('should return false when <html> has the "dark" class', () => {
+      document.documentElement.classList.add('dark');
+      expect(provider.getIsLightTheme()).toBe(false);
+    });
+  });
+
+  describe('getIsDirectory', () => {
+    it('should return true when icon has "ruyi-icon-folder" class', () => {
+      document.body.innerHTML =
+        '<svg class="ruyi-icon ruyi-icon-folder-colorful-colored"></svg>';
+      const icon = document.querySelector('svg') as unknown as HTMLElement;
+      expect(provider.getIsDirectory({ row: document.body, icon })).toBe(true);
+    });
+
+    it('should return false when icon does not have "ruyi-icon-folder" class', () => {
+      document.body.innerHTML = '<svg class="ruyi-icon ruyi-icon-file"></svg>';
+      const icon = document.querySelector('svg') as unknown as HTMLElement;
+      expect(provider.getIsDirectory({ row: document.body, icon })).toBe(false);
+    });
+  });
+
+  describe('getIsSubmodule', () => {
+    it('should always return false', () => {
+      document.body.innerHTML =
+        '<svg class="ruyi-icon ruyi-icon-folder-colorful-colored"></svg>';
+      const icon = document.querySelector('svg') as unknown as HTMLElement;
+      expect(provider.getIsSubmodule({ row: document.body, icon })).toBe(false);
+    });
+  });
+
+  describe('getIsSymlink', () => {
+    it('should always return false', () => {
+      document.body.innerHTML = '<svg class="ruyi-icon ruyi-icon-file"></svg>';
+      const icon = document.querySelector('svg') as unknown as HTMLElement;
+      expect(provider.getIsSymlink({ row: document.body, icon })).toBe(false);
+    });
+  });
+
+  describe('replaceIcon', () => {
+    it('should copy attributes from old element to new element', () => {
+      document.body.innerHTML =
+        '<div><svg class="ruyi-icon ruyi-icon-file" data-custom="value"></svg></div>';
+      const svgEl = document.querySelector('svg') as unknown as HTMLElement;
+      const newSVG = document.createElement('img') as unknown as HTMLElement;
+
+      provider.replaceIcon(svgEl, newSVG);
+
+      expect(newSVG.getAttribute('class')).toBe('ruyi-icon ruyi-icon-file');
+      expect(newSVG.getAttribute('data-custom')).toBe('value');
+    });
+
+    it('should NOT copy "src" attribute', () => {
+      document.body.innerHTML = '<div><svg src="old.svg"></svg></div>';
+      const svgEl = document.querySelector('svg') as unknown as HTMLElement;
+      const newSVG = document.createElement('img') as unknown as HTMLElement;
+
+      provider.replaceIcon(svgEl, newSVG);
+
+      expect(newSVG.getAttribute('src')).toBeNull();
+    });
+
+    it('should NOT copy "id" attribute', () => {
+      document.body.innerHTML =
+        '<div><svg id="folder-colorful-colored" class="ruyi-icon"></svg></div>';
+      const svgEl = document.querySelector('svg') as unknown as HTMLElement;
+      const newSVG = document.createElement('img') as unknown as HTMLElement;
+
+      provider.replaceIcon(svgEl, newSVG);
+
+      expect(newSVG.getAttribute('id')).toBeNull();
+    });
+
+    it('should NOT copy "data-material-icons-extension-*" attributes', () => {
+      document.body.innerHTML =
+        '<div><svg data-material-icons-extension="icon" data-material-icons-extension-iconname="test.svg"></svg></div>';
+      const svgEl = document.querySelector('svg') as unknown as HTMLElement;
+      const newSVG = document.createElement('img') as unknown as HTMLElement;
+
+      provider.replaceIcon(svgEl, newSVG);
+
+      expect(newSVG.getAttribute('data-material-icons-extension')).toBeNull();
+      expect(
+        newSVG.getAttribute('data-material-icons-extension-iconname')
+      ).toBeNull();
+    });
+
+    it('should set height to 16px and width to 16px', () => {
+      document.body.innerHTML = '<div><svg class="ruyi-icon"></svg></div>';
+      const svgEl = document.querySelector('svg') as unknown as HTMLElement;
+      const newSVG = document.createElement('img') as unknown as HTMLElement;
+
+      provider.replaceIcon(svgEl, newSVG);
+
+      expect(newSVG.style.height).toBe('16px');
+      expect(newSVG.style.width).toBe('16px');
+    });
+
+    it('should replace the old element in the DOM via parentNode.replaceChild', () => {
+      document.body.innerHTML =
+        '<div class="container"><svg class="ruyi-icon ruyi-icon-file"></svg></div>';
+      const container = document.querySelector('.container') as HTMLElement;
+      const svgEl = document.querySelector('svg') as unknown as HTMLElement;
+      const newSVG = document.createElement('img') as unknown as HTMLElement;
+
+      provider.replaceIcon(svgEl, newSVG);
+
+      expect(container.contains(svgEl)).toBe(false);
+      expect(container.contains(newSVG)).toBe(true);
+    });
+  });
+
+  describe('onAdd', () => {
+    it('should be a no-op function', () => {
+      const row = document.createElement('div');
+      const callback = () => {};
+      // Should not throw
+      expect(() => provider.onAdd(row, callback)).not.toThrow();
+    });
+  });
+
+  describe('transformFileName', () => {
+    it('should pass through filenames unchanged', () => {
+      const row = document.createElement('div');
+      const icon = document.createElement('i');
+      expect(provider.transformFileName(row, icon, 'index.ts')).toBe(
+        'index.ts'
+      );
+      expect(
+        provider.transformFileName(row, icon, 'DBX_0.5.77_x64-portable.zip')
+      ).toBe('DBX_0.5.77_x64-portable.zip');
+    });
+
+    it('should transform "Source code（zip）" to "Source code.zip"', () => {
+      const row = document.createElement('div');
+      const icon = document.createElement('i');
+      expect(provider.transformFileName(row, icon, 'Source code（zip）')).toBe(
+        'Source code.zip'
+      );
+    });
+
+    it('should transform "Source code（tar.gz）" to "Source code.tar.gz"', () => {
+      const row = document.createElement('div');
+      const icon = document.createElement('i');
+      expect(
+        provider.transformFileName(row, icon, 'Source code（tar.gz）')
+      ).toBe('Source code.tar.gz');
+    });
+
+    it('should also transform half-width "Source code (zip)"', () => {
+      const row = document.createElement('div');
+      const icon = document.createElement('i');
+      expect(provider.transformFileName(row, icon, 'Source code (zip)')).toBe(
+        'Source code.zip'
+      );
+    });
+  });
+
+  describe('selectors', () => {
+    it('should select file list table rows', () => {
+      document.body.innerHTML = `
+        <table class="cnb-file-table">
+          <tbody>
+            <tr><td></td></tr>
+            <tr><td></td></tr>
+          </tbody>
+        </table>`;
+      expect(document.querySelectorAll(provider.selectors.row).length).toBe(2);
+    });
+
+    it('should select release asset rows', () => {
+      document.body.innerHTML = `
+        <div class="w-full" id="asset">
+          <div class="overflow-x-auto">
+            <div class="w-full relative flex"></div>
+            <div class="w-full relative flex"></div>
+          </div>
+        </div>`;
+      expect(document.querySelectorAll(provider.selectors.row).length).toBe(2);
+    });
+
+    it('should select the filename span in the file list', () => {
+      document.body.innerHTML =
+        '<div><span class="ml-2 truncate">index.ts</span></div>';
+      expect(
+        document.querySelector(provider.selectors.filename)?.textContent
+      ).toBe('index.ts');
+    });
+
+    it('should select the download link in release rows', () => {
+      document.body.innerHTML =
+        '<div><a href="/releases/download/v0.5.77/latest.json" download="">latest.json</a></div>';
+      expect(
+        document.querySelector(provider.selectors.filename)?.textContent
+      ).toBe('latest.json');
+    });
+
+    it('should select the ruyi icon svg', () => {
+      document.body.innerHTML =
+        '<div><svg class="ruyi-icon ruyi-icon-file"></svg></div>';
+      expect(
+        document
+          .querySelector(provider.selectors.icon)
+          ?.classList.contains('ruyi-icon')
+      ).toBe(true);
+    });
+  });
+});

--- a/src/providers/cnb.ts
+++ b/src/providers/cnb.ts
@@ -1,0 +1,63 @@
+import { Provider } from '../models';
+
+export default function cnb(): Provider {
+  return {
+    name: 'cnb',
+    domains: [
+      {
+        host: 'cnb.cool',
+        test: /^cnb\.cool$/,
+      },
+    ],
+    selectors: {
+      // File list table row, release asset row
+      row: `.cnb-file-table tbody tr,
+        #asset .overflow-x-auto > div`,
+      // Filename span inside the file list anchor, release asset download link
+      filename: `span.ml-2,
+        a[download]`,
+      // The ruyi iconfont-style SVG (the first one in the row is the file icon)
+      icon: `svg.ruyi-icon`,
+      // Element by which to detect if the tested domain is cnb.
+      detect: null,
+    },
+    canSelfHost: false,
+    isCustom: false,
+    getIsLightTheme: () => {
+      // Dark mode is enabled via `class="dark"` on the <html> element.
+      return !document.querySelector('html')?.classList.contains('dark');
+    },
+    getIsDirectory: ({ icon }) =>
+      Array.from(icon.classList).some((className) =>
+        className.startsWith('ruyi-icon-folder')
+      ),
+    getIsSubmodule: () => false,
+    getIsSymlink: () => false,
+    replaceIcon: (svgEl, newSVG) => {
+      svgEl
+        .getAttributeNames()
+        .forEach(
+          (attr) =>
+            attr !== 'src' &&
+            attr !== 'id' &&
+            !/^data-material-icons-extension/.test(attr) &&
+            newSVG.setAttribute(attr, svgEl.getAttribute(attr) ?? '')
+        );
+
+      newSVG.style.height = '16px';
+      newSVG.style.width = '16px';
+
+      svgEl.parentNode?.replaceChild(newSVG, svgEl);
+    },
+    onAdd: () => {},
+    transformFileName: (
+      _rowEl: HTMLElement,
+      _iconEl: HTMLElement,
+      fileName: string
+    ) =>
+      // try to match the 'Source code（zip）' type of rows in releases page.
+      fileName.includes('Source code')
+        ? fileName.replace(/\s*[（(](.*?)[)）]$/, '.$1')
+        : fileName,
+  };
+}

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -2,6 +2,7 @@ import { getCustomProviders } from '../lib/custom-providers';
 import { Provider } from '../models';
 import azure from './azure';
 import bitbucket from './bitbucket';
+import cnb from './cnb';
 import forgejo from './forgejo';
 import gitea from './gitea';
 import gitee from './gitee';
@@ -13,6 +14,7 @@ import tangled from './tangled';
 export const providers: Record<string, () => Provider> = {
   azure,
   bitbucket,
+  cnb,
   gitea,
   gitee,
   github,


### PR DESCRIPTION
## Summary

Adds support for [cnb.cool](https://cnb.cool), a Git based code
hosting platform, by introducing a new `cnb` provider.

## Changes

- New `src/providers/cnb.ts` with selectors for:
  - File list table rows (`.cnb-file-table tbody tr`)
  - Release asset rows (`#asset .overflow-x-auto > div`)
  - Ruyi icon SVGs and the download link / filename span as targets
- `transformFileName` converts release rows like
  `Source code（zip）` → `Source code.zip` so archive icons resolve
- `getIsLightTheme` detects dark mode from the `dark` class on the
  `<html>` element
- Registered the provider in `src/providers/index.ts`
- Added `*://cnb.cool/*` to the manifest content scripts and web
  accessible resources in `src/manifests/base.json`
- Unit tests covering selectors, dark mode detection, and filename
  transformation

## Testing

- `npm test` — all tests pass
- `npm run check-type-safety` — passes

<img width="1535" height="867" alt="image" src="https://github.com/user-attachments/assets/a8ad392f-1950-447f-9de1-da0a798dcb3a" />
<img width="1370" height="848" alt="image" src="https://github.com/user-attachments/assets/952b3826-3c08-4518-b4c7-b9185a87acf7" />
